### PR TITLE
[IMPORTANT] Memory related fixes

### DIFF
--- a/include/http_header.h
+++ b/include/http_header.h
@@ -70,6 +70,7 @@ const char* encodingString(Encoding encoding);
 
 class Header {
 public:
+    virtual ~Header() {}
     virtual const char *name() const = 0;
 
     virtual void parse(const std::string& data);

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -58,6 +58,10 @@ struct SyncImpl : public Reactor::Impl {
 
     SyncImpl(Reactor* reactor)
         : Reactor::Impl(reactor)
+        , handlers_()
+        , shutdown_()
+        , shutdownFd()
+        , poller()
     {
         shutdownFd.bind(poller);
     }
@@ -204,7 +208,10 @@ private:
 
         static constexpr size_t MaxHandlers = (1 << HandlerBits) - 1;
 
-        HandlerList() {
+        HandlerList()
+            :handlers()
+            , index_()
+        {
             std::fill(std::begin(handlers), std::end(handlers), nullptr);
         }
 


### PR DESCRIPTION
This pull fixes 3 issues reported by valgrind.

**UMR issue:** Two variables were being used to loop but were not initialized in constructor) added them.
**Major memory leak:** The HttpHeaders destructor was not virtual leading to memory leak in Net::Http::Header::Accept::parseRaw which add MimeType objects to a vector. This would leak ~150 bytes every single request. I ran about 400K requests (Hello world) and it already leaked 74MB+ memory. This would make the framework completely unusable.

I request you to kindly run valgrind on your programs to detect these kinds of issues.