### PR TITLE
Fix build error on fedora 23

### DIFF
--- a/tests/async_test.cc
+++ b/tests/async_test.cc
@@ -5,6 +5,7 @@
 #include <deque>
 #include <mutex>
 #include <condition_variable>
+#include <random>
 
 Async::Promise<int> doAsync(int N)
 {


### PR DESCRIPTION
random_device is in the random header here. Without this include,
the build fails.
