### PR TITLE
Rename output library to libpistache

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,21 +1,21 @@
 add_executable(http_server http_server.cc)
-target_link_libraries(http_server net_static)
+target_link_libraries(http_server pistache_static)
 
 add_executable(hello_server hello_server.cc)
-target_link_libraries(hello_server net_static)
+target_link_libraries(hello_server pistache_static)
 
 add_executable(http_client http_client.cc)
-target_link_libraries(http_client net_static)
+target_link_libraries(http_client pistache_static)
 
 add_executable(custom_header custom_header.cc)
-target_link_libraries(custom_header net_static)
+target_link_libraries(custom_header pistache_static)
 
 add_executable(rest_server rest_server.cc)
-target_link_libraries(rest_server net_static)
+target_link_libraries(rest_server pistache_static)
 
 find_package(RapidJSON)
 if (RapidJSON_FOUND)
 include_directories(${RapidJSON_INCLUDE_DIRS})
 add_executable(rest_description rest_description.cc)
-target_link_libraries(rest_description net_static)
+target_link_libraries(rest_description pistache_static)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,11 @@ set(SOURCE_FILES
     ${CLIENT_SOURCE_FILES}
 )
 
-add_library(net_static ${SOURCE_FILES})
-target_link_libraries(net_static pthread)
-install(TARGETS net_static DESTINATION lib)
+add_library(pistache_static ${SOURCE_FILES})
+target_link_libraries(pistache_static pthread)
+install(TARGETS pistache_static DESTINATION lib)
 
-add_library(net SHARED ${SOURCE_FILES})
-target_link_libraries(net pthread)
-install(TARGETS net DESTINATION lib)
+add_library(pistache SHARED ${SOURCE_FILES})
+target_link_libraries(pistache pthread)
+install(TARGETS pistache DESTINATION lib)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_executable( run_mime_test mime_test.cc )
-target_link_libraries(run_mime_test gtest gtest_main net_static)
+target_link_libraries(run_mime_test gtest gtest_main pistache_static)
 add_test( mime_test run_mime_test )
 
 add_executable( run_headers_test headers_test.cc )
-target_link_libraries(run_headers_test gtest gtest_main net_static)
+target_link_libraries(run_headers_test gtest gtest_main pistache_static)
 add_test( headers_test run_headers_test )
 
 add_executable( run_async_test async_test.cc )
-target_link_libraries(run_async_test gtest gtest_main net_static)
+target_link_libraries(run_async_test gtest gtest_main pistache_static)
 add_test( async_test run_async_test )
 
 add_executable( run_typeid_test typeid_test.cc )
@@ -15,13 +15,13 @@ target_link_libraries(run_typeid_test gtest gtest_main pthread)
 add_test( typeid_test run_typeid_test )
 
 add_executable( run_router_test router_test.cc )
-target_link_libraries(run_router_test gtest gtest_main net_static)
+target_link_libraries(run_router_test gtest gtest_main pistache_static)
 add_test( router_test run_router_test )
 
 add_executable( run_cookie_test cookie_test.cc )
-target_link_libraries(run_cookie_test gtest gtest_main net_static)
+target_link_libraries(run_cookie_test gtest gtest_main pistache_static)
 add_test( cookie_test run_cookie_test )
 
 add_executable( run_view_test view_test.cc )
-target_link_libraries(run_view_test gtest gtest_main net_static)
+target_link_libraries(run_view_test gtest gtest_main pistache_static)
 add_test( view_test run_view_test )


### PR DESCRIPTION
The library is pistache.io. Having the binary produced named "libnet" is
weird, and something that conflicts with libnet, which is a packet
creation/injection library.