### PR TITLE
Use a std::function callback rather then std::cout to log data 

### DIFF
--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -76,10 +76,10 @@ private:
         listener.setHandler(handler_);
 
         if (listener.bind()) {
-            const auto& addr = listener.address();
-            std::string out = "Now listening on http://";
             if(logCallback_)
             {
+                const auto& addr = listener.address();
+                std::string out = "Now listening on http://";
                 out.append(addr.host());
                 out.append(":");
                 out.append(std::to_string(addr.port()));

--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -9,6 +9,7 @@
 #include "listener.h"
 #include "net.h"
 #include "http.h"
+#include <functional>
 
 namespace Net {
 
@@ -52,11 +53,17 @@ public:
         return listener.isBound();
     }
 
+    void setLogCallback(std::function<void(std::string)> cb){
+        logCallback_ = cb;
+    }
+
     Async::Promise<Tcp::Listener::Load> requestLoad(const Tcp::Listener::Load& old);
 
     static Options options();
 
 private:
+
+    std::function<void(std::string)> logCallback_;
 
     template<typename Method>
     void serveImpl(Method method)
@@ -69,8 +76,12 @@ private:
 
         if (listener.bind()) {
             const auto& addr = listener.address();
-            std::cout << "Now listening on " << "http://" + addr.host() << ":"
-                      << addr.port() << std::endl;
+            std::string out = "Now listening on http://";
+            out.append(addr.host());
+            out.append(":");
+            out.append(std::to_string(addr.port()));
+
+            logCallback_(out);
             CALL_MEMBER_FN(listener, method)();
         }
 #undef CALL_MEMBER_FN

--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -10,6 +10,7 @@
 #include "net.h"
 #include "http.h"
 #include <functional>
+#include <iostream>
 
 namespace Net {
 
@@ -77,11 +78,13 @@ private:
         if (listener.bind()) {
             const auto& addr = listener.address();
             std::string out = "Now listening on http://";
-            out.append(addr.host());
-            out.append(":");
-            out.append(std::to_string(addr.port()));
-
-            logCallback_(out);
+            if(logCallback_)
+            {
+                out.append(addr.host());
+                out.append(":");
+                out.append(std::to_string(addr.port()));
+                logCallback_(out);
+            }
             CALL_MEMBER_FN(listener, method)();
         }
 #undef CALL_MEMBER_FN

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -37,12 +37,12 @@ Endpoint::Options::backlog(int val) {
 }
 
 Endpoint::Endpoint() { 
-    logCallback_ = [](std::string log) { std::cout << log << std::cout; };
+    logCallback_ = [](std::string log) { std::cout << log << std::endl; };
 }
 
 Endpoint::Endpoint(const Net::Address& addr)
     : listener(addr) {
-    logCallback_ = [](std::string log) { std::cout << log << std::cout; };
+    logCallback_ = [](std::string log) { std::cout << log << std::endl; };
 }
 
 void

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -36,12 +36,14 @@ Endpoint::Options::backlog(int val) {
     return *this;
 }
 
-Endpoint::Endpoint()
-{ }
+Endpoint::Endpoint() { 
+    logCallback_ = [](std::string log) { std::cout << log << std::cout; };
+}
 
 Endpoint::Endpoint(const Net::Address& addr)
-    : listener(addr)
-{ }
+    : listener(addr) {
+    logCallback_ = [](std::string log) { std::cout << log << std::cout; };
+}
 
 void
 Endpoint::init(const Endpoint::Options& options) {


### PR DESCRIPTION
I'm using pistache in several projects now and what stressed me is the common use of std::cout's.
This is a example on how to use callbacks for log-messages, with std::cout fallback.