### PR TITLE
Enables gdb debugging by fixing the polling code to allow interrupts.

### DIFF
--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -187,7 +187,11 @@ namespace Polling {
     Epoll::poll(std::vector<Event>& events, size_t maxEvents, std::chrono::milliseconds timeout) const {
         struct epoll_event evs[Const::MaxEvents];
 
-        int ready_fds = epoll_wait(epoll_fd, evs, maxEvents, timeout.count());
+        int ready_fds = -1;
+        do {
+            ready_fds = epoll_wait(epoll_fd, evs, maxEvents, timeout.count());
+        } while (ready_fds < 0 && errno == EINTR);
+
         if (ready_fds > 0) {
             for (int i = 0; i < ready_fds; ++i) {
                 const struct epoll_event *ev = evs + i;


### PR DESCRIPTION
@michalpelka hit an issue ( #29 ) where attaching gdb and stepping
through code fails with a `terminate called after throwing an instance of
'Net::Error' what(): Polling: Interrupted system call`.  @michalpelka then
identified the fix which involves continuing to call `epoll` in the event
of an interrupt

After build `make test` passed and I can confirm that the fix enables the 
use of `gdb` and `gdbtui`.