### PR TITLE
fixes #49

### DIFF
--- a/include/stream.h
+++ b/include/stream.h
@@ -143,7 +143,7 @@ struct Buffer {
         char *newData = new char[len - fromIndex];
         std::copy(data + fromIndex, data + len, newData);
 
-        return Buffer(newData, len, true);
+        return Buffer(newData, len - fromIndex, true);
     }
 
     const char* const data;

--- a/include/stream.h
+++ b/include/stream.h
@@ -141,7 +141,7 @@ struct Buffer {
             throw std::invalid_argument("Invalid index (> len)");
 
         char *newData = new char[len - fromIndex];
-        std::copy(data + fromIndex, data + len - fromIndex, newData);
+        std::copy(data + fromIndex, data + len, newData);
 
         return Buffer(newData, len, true);
     }

--- a/include/transport.h
+++ b/include/transport.h
@@ -54,7 +54,8 @@ public:
                 return;
             }
 
-            asyncWriteImpl(fd, flags, BufferHolder(buffer), Async::Deferred<ssize_t>(std::move(resolve), std::move(reject)));
+            ssize_t bytesWritten = 0;
+            asyncWriteImpl(fd, flags, BufferHolder(buffer), bytesWritten, Async::Deferred<ssize_t>(std::move(resolve), std::move(reject)));
 
         });
     }
@@ -157,12 +158,14 @@ private:
             , buffer(std::move(buffer))
             , flags(flags)
             , peerFd(-1)
+            , bytesWritten(0)
         { }
 
         Async::Deferred<ssize_t> deferred;
         BufferHolder buffer;
         int flags;
         Fd peerFd;
+        ssize_t bytesWritten;
     };
 
     struct TimerEntry {
@@ -240,7 +243,7 @@ private:
 
     void asyncWriteImpl(Fd fd, WriteEntry& entry, WriteStatus status = FirstTry);
     void asyncWriteImpl(
-            Fd fd, int flags, const BufferHolder& buffer,
+            Fd fd, int flags, const BufferHolder& buffer, ssize_t& bytesWritten,
             Async::Deferred<ssize_t> deferred,
             WriteStatus status = FirstTry);
 

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -166,12 +166,12 @@ Transport::handlePeerDisconnection(const std::shared_ptr<Peer>& peer) {
 
 void
 Transport::asyncWriteImpl(Fd fd, Transport::WriteEntry& entry, WriteStatus status) {
-    asyncWriteImpl(fd, entry.flags, entry.buffer, std::move(entry.deferred), status);
+    asyncWriteImpl(fd, entry.flags, entry.buffer, entry.bytesWritten, std::move(entry.deferred), status);
 }
 
 void
 Transport::asyncWriteImpl(
-        Fd fd, int flags, const BufferHolder& buffer,
+        Fd fd, int flags, const BufferHolder& buffer, ssize_t& totalWritten,
         Async::Deferred<ssize_t> deferred, WriteStatus status)
 {
     auto cleanUp = [&]() {
@@ -184,7 +184,6 @@ Transport::asyncWriteImpl(
             toWrite.erase(fd);
     };
 
-    ssize_t totalWritten = 0;
     for (;;) {
         ssize_t bytesWritten = 0;
         auto len = buffer.size() - totalWritten;

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -215,7 +215,7 @@ Transport::asyncWriteImpl(
         }
         else {
             totalWritten += bytesWritten;
-            if (totalWritten == len) {
+            if (totalWritten == buffer.size()) {
                 cleanUp();
                 deferred.resolve(totalWritten);
                 break;


### PR DESCRIPTION
fix Buffer::Detach copying incorrect data range
fix Transport::asyncWriteImpl expecting the incorrect number of bytes to
be written when a write is split over multiple sends