### PR TITLE
Patches for Arch Linux packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 3.0.2)
 project (pistache)
 include(CheckCXXCompilerFlag)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,3 +40,23 @@ install(
   DIRECTORY "${PROJECT_SOURCE_DIR}/include/pistache"
   DESTINATION ${include_install_dir}
   FILES_MATCHING PATTERN "*.*h")
+install(TARGETS pistache
+        EXPORT PistacheTargets
+        DESTINATION lib)
+install(EXPORT PistacheTargets
+        DESTINATION "lib/cmake/pistache"
+        EXPORT_LINK_INTERFACE_LIBRARIES
+        COMPONENT cmake-config
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "PistacheConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/PistacheConfig.cmake"
+    INSTALL_DESTINATION "lib/cmake/pistache"
+)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/PistacheConfig.cmake"
+    DESTINATION "lib/cmake/pistache"
+    COMPONENT cmake-config
+)

--- a/src/PistacheConfig.cmake.in
+++ b/src/PistacheConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/PistacheTargets.cmake")


### PR DESCRIPTION
This PR contains 2 patches I created for Arch Linux packaging.

The first patch renames the library to `pistache` to avoid a conflict with libnet (https://www.archlinux.org/packages/extra/x86_64/libnet). I understand if you don't like renaming the targets because all projects using it would need to adopt. Note that libnet is more popular and there already packages for different distributions (https://repology.org/metapackage/libnet/versions).

The second patch builds currently on top of the first one. It adds CMake config files so the library can be used more easily from other CMake projects. Using the lib via such a config is better because it preserves link libs, compile definitions and other target properties.

BTW: For the package see https://aur.archlinux.org/packages/pistache-git / https://github.com/Martchus/PKGBUILDs/tree/master/pistache/git