### PR TITLE
Fix missing bind() and wrong comment

### DIFF
--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -1,6 +1,6 @@
 /* endpoint.cc
    Mathieu Stefani, 22 janvier 2016
-   
+
    Implementation of the http endpoint
 */
 
@@ -51,6 +51,16 @@ Endpoint::init(const Endpoint::Options& options) {
 void
 Endpoint::setHandler(const std::shared_ptr<Handler>& handler) {
     handler_ = handler;
+}
+
+void
+Endpoint::bind() {
+    listener.bind();
+}
+
+void
+Endpoint::bind(const Address& addr) {
+    listener.bind(addr);
 }
 
 void

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -351,7 +351,7 @@ void Options(Router& router, std::string resource, Route::Handler handler) {
     router.options(std::move(resource), std::move(handler));
 }
 
-} // namespace Routing
+} // namespace Routes
 
 } // namespace Rest
 


### PR DESCRIPTION
I assume Endpoint::bind() is supposed to be a wrapper for the bind() method of the underlying listener.