### PR TITLE
Include serializer code in CMake install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 file(GLOB HEADER_FILES "include/*.h")
 install(FILES ${HEADER_FILES} DESTINATION include/pistache)
 
+file(GLOB SERIALIZER_HEADER_FILES "include/serializer/*.h")
+install(FILES ${SERIALIZER_HEADER_FILES} DESTINATION include/pistache/serializer)
+
 add_subdirectory (src)
 include_directories (src)
 


### PR DESCRIPTION
In commit 76db321 when rapidjson dependency was removed, `/include/serializer/rapidjson.h` was introduced. However, the CMakeLists.txt was not adjusted to consider subdirectories of `/include` for installation. Therefore, projects modelled based on `/examples/rest_description.cc` fail to compile because `#include "serializer/rapidjson.h"` does not work.

This fixes the error by including `/include/serializer` in the CMake installation script.