### PR TITLE
Avoid macro invocation in examples

### DIFF
--- a/examples/custom_header.cc
+++ b/examples/custom_header.cc
@@ -46,11 +46,11 @@ public:
         os << "." << min;
     }
 
-    uint32_t major() const {
+    uint32_t majorVersion() const {
         return maj;
     }
 
-    uint32_t minor() const {
+    uint32_t minorVersion() const {
         return min;
     }
 


### PR DESCRIPTION
Alpine defines macros 'major' & 'minor', so the functions modified are
parsed as macro invocations. The rename avoids this collision.