### PR TITLE
README: fix hello world example so it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Full documentation is located at [http://pistache.io](http://pistache.io).
 using namespace Net;
 
 struct HelloHandler : public Http::Handler {
+    HTTP_PROTOTYPE(HelloHandler)
+
     void onRequest(const Http::Request& request, Http::ResponseWriter writer) {
         writer.send(Http::Code::Ok, "Hello, World!");
     }


### PR DESCRIPTION
Appearantly the HTTP_PROTOTYPE macro is needed, otherwise the example
won't compile.

The compile error was:
```
/usr/local/include/pistache/http.h:758:5: error: static assertion failed: An http handler must be an http prototype, did you forget the HTTP_PROTOTYPE macro ?
     static_assert(details::IsHttpPrototype<H>::value, "An http handler must be an http prototype, did you forget the HTTP_PROTOTYPE macro ?");
```

The fix was also mentioned in #71 but it seems the README didn't actually get updated.