### PR TITLE
Allow the address to be retreived via an Endpoint.

### DIFF
--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -52,6 +52,8 @@ public:
         return listener.isBound();
     }
 
+    Address address() const;
+
     Async::Promise<Tcp::Listener::Load> requestLoad(const Tcp::Listener::Load& old);
 
     static Options options();

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -63,6 +63,10 @@ Endpoint::bind(const Address& addr) {
     listener.bind(addr);
 }
 
+Address Endpoint::address() const {
+    return listener.address();
+}
+
 void
 Endpoint::serve()
 {

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -81,6 +81,7 @@ Listener::Listener(const Address& address)
     : addr_(address)
     , listen_fd(-1)
     , backlog_(Const::MaxBacklog)
+    , workers_(1)
     , reactor_(Aio::Reactor::create())
 {
 }
@@ -191,6 +192,14 @@ Listener::bind(const Address& address) {
 
     reactor_->init(Aio::AsyncContext(workers_));
     transportKey = reactor_->addHandler(transport_);
+
+    struct sockaddr realAddr;
+    socklen_t addrLen = sizeof(realAddr);
+
+    if (!addr_.port() && !::getsockname(fd, &realAddr, &addrLen))
+    {
+        addr_ = Address::fromUnix(&realAddr);
+    }
 
     return true;
 }


### PR DESCRIPTION
To support a microservice scenario with a Net::Http::Endpoint, it is desirable to allow the user to specify
the port as 0, and have the operating system assign a free port.  But to do so requires reading the port
from the socket after creation, so that it can be registered with the service discovery mechanism.

The alternative of opening a socket on a random port, then reusing the port to initialise an Endpoint
exposes you to problems caused by race conditions.