### PR TITLE
Support requests larger than 4k

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -52,6 +52,6 @@ namespace Const {
 
     static constexpr int MaxBacklog = 128;
     static constexpr int MaxEvents = 1024;
-    static constexpr int MaxBuffer = 4096;
+    static constexpr size_t BufferSize = 4096;
     static constexpr int ChunkSize = 1024;
 }

--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -22,11 +22,13 @@ public:
         Options& threads(int val);
         Options& flags(Flags<Tcp::Options> flags);
         Options& backlog(int val);
+        Options& maxBufferSize(size_t val);
 
     private:
         int threads_;
         Flags<Tcp::Options> flags_;
         int backlog_;
+        size_t maxBufferSize_;
         Options();
     };
     Endpoint();

--- a/include/http.h
+++ b/include/http.h
@@ -670,7 +670,7 @@ namespace Private {
 
         State parse();
 
-        ArrayStreamBuf<Const::BufferSize> buffer;
+        SmallStreamBuf<Const::BufferSize> buffer;
         StreamCursor cursor;
 
     protected:

--- a/include/listener.h
+++ b/include/listener.h
@@ -45,7 +45,8 @@ public:
     void init(
             size_t workers,
             Flags<Options> options = Options::None,
-            int backlog = Const::MaxBacklog);
+            int backlog = Const::MaxBacklog,
+            size_t maxBufferSize = Const::BufferSize);
     void setHandler(const std::shared_ptr<Handler>& handler);
 
     bool bind();
@@ -69,6 +70,7 @@ private:
     Address addr_; 
     int listen_fd;
     int backlog_;
+    size_t maxBufferSize_;
     NotifyFd shutdownFd;
     Polling::Epoll poller;
 

--- a/include/peer.h
+++ b/include/peer.h
@@ -53,6 +53,8 @@ public:
 
     Async::Promise<ssize_t> send(const Buffer& buffer, int flags = 0);
 
+    size_t getMaxBufferSize() const;
+
 private:
     void associateTransport(Transport* transport);
     Transport* transport() const;

--- a/include/stream.h
+++ b/include/stream.h
@@ -118,6 +118,10 @@ public:
         Base::setg(bytes, bytes, bytes);
     }
 
+    size_t getSize() const {
+        return size;
+    }
+
 private:
     char bytes[N];
     size_t size;

--- a/include/transport.h
+++ b/include/transport.h
@@ -21,7 +21,7 @@ class Handler;
 
 class Transport : public Aio::Handler {
 public:
-    Transport(const std::shared_ptr<Tcp::Handler>& handler);
+    Transport(const std::shared_ptr<Tcp::Handler>& handler, size_t maxBufferSize);
 
     void init(const std::shared_ptr<Tcp::Handler>& handler);
 
@@ -78,6 +78,8 @@ public:
     void disarmTimer(Fd fd);
 
     std::shared_ptr<Aio::Handler> clone() const;
+
+    size_t getMaxBufferSize() const;
 
 private:
     enum WriteStatus {
@@ -222,6 +224,8 @@ private:
     NotifyFd notifier;
 
     std::shared_ptr<Tcp::Handler> handler_;
+
+    size_t maxBufferSize_;
 
     bool isPeerFd(Fd fd) const;
     bool isTimerFd(Fd fd) const;

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -312,7 +312,7 @@ Transport::handleConnectionQueue() {
 
 void
 Transport::handleIncoming(const std::shared_ptr<Connection>& connection) {
-    char buffer[Const::MaxBuffer];
+    char buffer[Const::BufferSize];
     memset(buffer, 0, sizeof buffer);
 
     ssize_t totalBytes = 0;
@@ -320,7 +320,7 @@ Transport::handleIncoming(const std::shared_ptr<Connection>& connection) {
 
         ssize_t bytes;
 
-        bytes = recv(connection->fd, buffer + totalBytes, Const::MaxBuffer - totalBytes, 0);
+        bytes = recv(connection->fd, buffer + totalBytes, Const::BufferSize - totalBytes, 0);
         if (bytes == -1) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 if (totalBytes > 0) {
@@ -344,7 +344,7 @@ Transport::handleIncoming(const std::shared_ptr<Connection>& connection) {
 
         else {
             totalBytes += bytes;
-            if (totalBytes >= Const::MaxBuffer) {
+            if (totalBytes >= Const::BufferSize) {
                 std::cerr << "Too long packet" << std::endl;
                 break;
             }

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -462,7 +462,7 @@ namespace Private {
 
     bool
     ParserBase::feed(const char* data, size_t len) {
-        return buffer.feed(data, len);
+        return buffer.feed(data, len) && (!maxBufferSize || buffer.getSize() <= maxBufferSize);
     }
 
     void
@@ -767,7 +767,7 @@ Handler::onInput(const char* buffer, size_t len, const std::shared_ptr<Tcp::Peer
 
 void
 Handler::onConnection(const std::shared_ptr<Tcp::Peer>& peer) {
-    peer->putData(ParserData, std::make_shared<Private::Parser<Http::Request>>());
+    peer->putData(ParserData, std::make_shared<Private::Parser<Http::Request>>(peer->getMaxBufferSize()));
 }
 
 void

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -462,7 +462,8 @@ namespace Private {
 
     bool
     ParserBase::feed(const char* data, size_t len) {
-        return buffer.feed(data, len) && (!maxBufferSize || buffer.getSize() <= maxBufferSize);
+        buffer.feed(data, len);
+        return (!maxBufferSize || buffer.getSize() <= maxBufferSize);
     }
 
     void

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -84,6 +84,11 @@ Peer::send(const Buffer& buffer, int flags) {
     return transport()->asyncWrite(fd_, buffer, flags);
 }
 
+size_t
+Peer::getMaxBufferSize() const {
+    return transport()->getMaxBufferSize();
+}
+
 std::ostream& operator<<(std::ostream& os, const Peer& peer) {
     const auto& addr = peer.address();
     os << "(" << addr.host() << ", " << addr.port() << ") [" << peer.hostname() << "]";

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -59,10 +59,12 @@ DynamicStreamBuf::overflow(DynamicStreamBuf::int_type ch) {
 void
 DynamicStreamBuf::reserve(size_t size)
 {
+    const auto getpos = this->gptr() - this->eback();
     if (size > maxSize_) size = maxSize_;
     const size_t oldSize = data_.size();
     data_.resize(size);
     this->setp(&data_[0] + oldSize, &data_[0] + size);
+    this->setg(&data_[0], &data_[0] + getpos, &data_[0] + size);
 }
 
 bool

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -16,6 +16,8 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
+    , backlog_(Const::MaxBacklog)
+    , maxBufferSize_(Const::BufferSize)
 { }
 
 Endpoint::Options&
@@ -36,6 +38,12 @@ Endpoint::Options::backlog(int val) {
     return *this;
 }
 
+Endpoint::Options&
+Endpoint::Options::maxBufferSize(size_t val) {
+    maxBufferSize_ = val;
+    return *this;
+}
+
 Endpoint::Endpoint()
 { }
 
@@ -45,7 +53,7 @@ Endpoint::Endpoint(const Net::Address& addr)
 
 void
 Endpoint::init(const Endpoint::Options& options) {
-    listener.init(options.threads_, options.flags_);
+    listener.init(options.threads_, options.flags_, options.backlog_, options.maxBufferSize_);
 }
 
 void

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -93,7 +93,9 @@ Listener::~Listener() {
 void
 Listener::init(
     size_t workers,
-    Flags<Options> options, int backlog)
+    Flags<Options> options,
+    int backlog,
+    size_t maxBufferSize)
 {
     if (workers > hardware_concurrency()) {
         // Log::warning() << "More workers than available cores"
@@ -101,6 +103,7 @@ Listener::init(
 
     options_ = options;
     backlog_ = backlog;
+    maxBufferSize_ = maxBufferSize;
 
     if (options_.hasFlag(Options::InstallSignalHandler)) {
         if (signal(SIGINT, handle_sigint) == SIG_ERR) {
@@ -187,7 +190,7 @@ Listener::bind(const Address& address) {
     listen_fd = fd;
     g_listen_fd = fd;
 
-    transport_.reset(new Transport(handler_));
+    transport_.reset(new Transport(handler_, maxBufferSize_));
 
     reactor_->init(Aio::AsyncContext(workers_));
     transportKey = reactor_->addHandler(transport_);


### PR DESCRIPTION
A request size of 4k is too small for some use cases.  This change makes it a runtime configurable parameter, with the option to make it unbounded, by setting the limit to 0.

There is a small buffer optimisation that will utilise the existing `ArrayStreamBuf` for requests < 4k, and the `DynamicStreamBuf` for anything larger.