### PR TITLE
Large response fix

### DIFF
--- a/include/stream.h
+++ b/include/stream.h
@@ -140,10 +140,11 @@ struct Buffer {
         if (fromIndex > len)
             throw std::invalid_argument("Invalid index (> len)");
 
-        char *newData = new char[len - fromIndex];
-        std::copy(data + fromIndex, data + len - fromIndex, newData);
+        const auto newLen = len - fromIndex;
+        char *newData = new char[newLen];
+        std::copy(data + fromIndex, data + fromIndex + newLen, newData);
 
-        return Buffer(newData, len, true);
+        return Buffer(newData, newLen, true);
     }
 
     const char* const data;


### PR DESCRIPTION
The detach method was not properly copying data to the new buffer, and was passing the wrong length to
the Buffer object.  This resulted in corrupt data transfers when the data to be sent was too big to be sent
at once, and ::send call in Transport::asyncWriteImpl fails with EAGAIN/EWOULDBLOCK.