### PR TITLE
Fix class\struct inconsistency warnings

### DIFF
--- a/include/async.h
+++ b/include/async.h
@@ -156,7 +156,7 @@ namespace Async {
             }
         };
 
-        class Core;
+        struct Core;
 
         class Request {
         public:
@@ -1099,7 +1099,7 @@ namespace Async {
 
     class Any {
     public:
-        friend class Impl::Any;
+        friend struct Impl::Any;
 
         Any(const Any& other) = default;
         Any& operator=(const Any& other) = default;


### PR DESCRIPTION
Warnings reported by Visual Studio. Nothing serious, but still, less warnings - better.