### PR TITLE
Ignore case in HTTP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build files
+build
+
 # Compiled Object files
 *.slo
 *.lo

--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -54,7 +54,7 @@ namespace Const {
 
     static constexpr int MaxBacklog = 128;
     static constexpr int MaxEvents = 1024;
-    static constexpr int MaxBuffer = 4096;
+    static constexpr int MaxBuffer = 1048576;
     static constexpr int ChunkSize = 1024;
 } // namespace Const
 } // namespace Pistache

--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <functional>
+#include <algorithm>
 #include <unordered_map>
 #include <vector>
 #include <memory>
@@ -15,6 +17,21 @@
 namespace Pistache {
 namespace Http {
 namespace Header {
+
+std::string
+toLowercase(std::string str);
+
+struct LowercaseHash {
+    size_t operator()(const std::string& key) const {
+        return std::hash<std::string>{}(toLowercase(key));
+    }
+};
+
+struct LowercaseEqual {
+    bool operator()(const std::string& left, const std::string& right) const {
+        return toLowercase(left) == toLowercase(right);
+    }
+};
 
 class Collection {
 public:
@@ -94,7 +111,12 @@ public:
 private:
     std::pair<bool, std::shared_ptr<Header>> getImpl(const std::string& name) const;
 
-    std::unordered_map<std::string, std::shared_ptr<Header>> headers;
+    std::unordered_map<
+        std::string,
+        std::shared_ptr<Header>,
+        LowercaseHash,
+        LowercaseEqual
+    > headers;
     std::unordered_map<std::string, Raw> rawHeaders;
 };
 

--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -16,7 +16,12 @@ namespace Http {
 namespace Header {
 
 namespace {
-    std::unordered_map<std::string, Registry::RegistryFunc> registry;
+    std::unordered_map<
+        std::string,
+        Registry::RegistryFunc,
+        LowercaseHash,
+        LowercaseEqual
+    > registry;
 }
 
 RegisterHeader(Accept);
@@ -33,6 +38,12 @@ RegisterHeader(Host);
 RegisterHeader(Location);
 RegisterHeader(Server);
 RegisterHeader(UserAgent);
+
+std::string
+toLowercase(std::string str) {
+    std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+    return str;
+}
 
 void
 Registry::registerHeader(std::string name, Registry::RegistryFunc func)


### PR DESCRIPTION
Closes #106.
Closes #86.
Closes #80.
Replaces #13.