### PR TITLE
Prevent race between queueing req and connecting

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -76,9 +76,18 @@ struct Connection : public std::enable_shared_from_this<Connection> {
     void connect(Address addr);
     void close();
     bool isIdle() const;
-    bool isConnected() const;
+    bool isConnected();
     bool hasTransport() const;
     void associateTransport(const std::shared_ptr<Transport>& transport);
+
+    bool isConnectedPushReqEntryIfNot(Async::Resolver & resolve,
+                                      Async::Rejection & reject,
+                                      const Http::Request& request,
+                                      std::chrono::milliseconds timeout,
+                                      const OnDone & onDone);
+
+    void setConnectedProcessRequestQueue();
+    void setConnecting();
 
     Async::Promise<Response> perform(
             const Http::Request& request,
@@ -126,6 +135,7 @@ private:
     };
 
     std::atomic<uint32_t> state_;
+    std::mutex connectionStateMutex_;
     ConnectionState connectionState_;
     std::shared_ptr<Transport> transport_;
     Queue<RequestData> requestsQueue;


### PR DESCRIPTION
On my application I was seeing a client hang about 1 run in 10, which I think was due to this race condition.

In client.cc, Connection::perform would check the connectionState_ and, if connected would call performImpl to perform the request; or if not yet connected, would push a request onto requestsQueue for later processing.

Meanwhile over in Connection::connect, once connection was made, connectionState_ would be changed from Connecting to Connected and then processRequestQueue would be called.

To avoid a couple of race conditions, for Connection::perform the act of checking connectionState_ and queuing request if not yet connected needs to be atomic with respect to, in Connection::connect, the act of changing connection state to Connected and calling processRequestQueue.

With these changes I have not been able to recreate the client hang.