### PR TITLE
Fix memory leaks discovered by Valgrind

### DIFF
--- a/include/pistache/mailbox.h
+++ b/include/pistache/mailbox.h
@@ -155,6 +155,10 @@ public:
     struct Entry {
         friend class Queue;
 
+        Entry () {
+            memset(&storage, 0, sizeof(storage));
+        }
+
         const T& data() const {
             return *reinterpret_cast<const T*>(&storage);
         }
@@ -164,8 +168,10 @@ public:
         }
 
         ~Entry() {
-            auto *d = reinterpret_cast<T *>(&storage);
-            d->~T();
+            if(nullptr != *reinterpret_cast<void**>(&storage)) {
+                auto *d = reinterpret_cast<T *>(&storage);
+                d->~T();    
+            }
         }
     private:
         typedef typename std::aligned_storage<sizeof(T), alignof(T)>::type Storage;
@@ -183,6 +189,7 @@ public:
 
     virtual ~Queue() {
         while (auto *e = pop()) delete e;
+        delete tail; // delete sentinel.
     }
 
     template<typename U>


### PR DESCRIPTION
Fix memory leaks in two ways:

1. `freeaddrinfo` must be called after `getaddrinfo`.  

2.  The `sentinel` in `Queue<T>` was not being deleted in the destructor.  In addition to deleting the sentinel, I also added code to check if an Entry has been initialized before calling the `Entry` destructor.