### PR TITLE
Support musl based compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@ dist: trusty
 script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make
 compiler:
     - clang
-    - gcc
+    - gcc-5
+before_install:
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libyajl-dev libxml2-dev libxqilla-dev
+    - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-5-dev; fi
+    - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-5; fi
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
 branches:
     only:
         - master

--- a/include/pistache/http_header.h
+++ b/include/pistache/http_header.h
@@ -326,6 +326,7 @@ public:
         fullDate_(date)
     { }
 
+    void parse(const std::string& data);
     void parseRaw(const char* str, size_t len);
     void write(std::ostream& os) const;
 

--- a/src/common/http_defs.cc
+++ b/src/common/http_defs.cc
@@ -14,20 +14,31 @@ namespace Pistache {
 namespace Http {
 
 namespace {
-    bool parseRFC1123Date(std::tm& tm, const char* str, size_t len) {
-        char *p = strptime(str, "%a, %d %b %Y %H:%M:%S %Z", &tm);
-        return p != NULL;
+    bool parseRFC1123Date(std::tm& tm, const std::string& str) {
+        std::istringstream ss(str);
+        ss >> std::get_time(&tm, "%a, %d %b %Y %H:%M:%S %Z");
+        return !ss.fail();
     }
 
-    bool parseRFC850Date(std::tm& tm, const char* str, size_t len) {
-        char *p = strptime(str, "%A, %d-%b-%y %H:%M:%S %Z", &tm);
-        return p != NULL;
+    bool parseRFC850Date(std::tm& tm, const std::string& str) {
+        std::istringstream ss(str);
+        ss >> std::get_time(&tm, "%A, %d-%b-%y %H:%M:%S %Z");
+        return !ss.fail();
     }
-
-    bool parseAscTimeDate(std::tm& tm, const char* str, size_t len) {
+    
+    bool parseAscTimeDateRaw(std::tm& tm, const char* str, size_t len) {
         char *p = strptime(str, "%a %b  %d %H:%M:%S %Y", &tm);
         return p != NULL;
     }
+
+    bool parseAscTimeDate(std::tm& tm, const std::string& str) {
+        //FIXME this always fail. Why? https://stackoverflow.com/questions/44901711/convert-ansi-cs-asctime-format-using-stdget-time
+        //std::istringstream ss(str);
+        //ss >> std::get_time(&tm, "%a %b  %d %H:%M:%S %Y");
+        //return !ss.fail();
+        return parseAscTimeDateRaw(tm, str.c_str(), str.size());
+    }
+    
 } // anonymous namespace
 
 CacheDirective::CacheDirective(Directive directive)
@@ -84,28 +95,30 @@ FullDate::FullDate() {
 FullDate
 FullDate::fromRaw(const char* str, size_t len)
 {
-    // As per the RFC, implementation MUST support all three formats.
-    std::tm tm = {};
-    if (parseRFC1123Date(tm, str, len)) {
-        return FullDate(tm);
-    }
-
-    memset(&tm, 0, sizeof tm);
-    if (parseRFC850Date(tm, str, len)) {
-        return FullDate(tm);
-    }
-    memset(&tm, 0, sizeof tm);
-
-    if (parseAscTimeDate(tm, str, len)) {
-        return FullDate(tm);
-    }
-
-    throw std::runtime_error("Invalid Date format");
+    const std::string s = std::string(str, len);
+    return fromString(s);
 }
 
 FullDate
 FullDate::fromString(const std::string& str) {
-    return FullDate::fromRaw(str.c_str(), str.size());
+    
+    // As per the RFC, implementation MUST support all three formats.
+    std::tm tm = {};
+    if(parseRFC1123Date(tm, str)){
+        return FullDate(tm);
+    }
+    
+    memset(&tm, 0, sizeof tm);
+    if(parseRFC850Date(tm, str)){
+        return FullDate(tm);
+    }
+    
+    memset(&tm, 0, sizeof tm);
+    if(parseAscTimeDate(tm, str)) {
+        return FullDate(tm);
+    }
+
+    throw std::runtime_error("Invalid Date format");
 }
 
 void

--- a/src/common/http_header.cc
+++ b/src/common/http_header.cc
@@ -304,6 +304,11 @@ ContentLength::write(std::ostream& os) const {
 }
 
 void
+Date::parse(const std::string& data) {
+    fullDate_ = FullDate::fromString(data);
+}
+
+void
 Date::parseRaw(const char* str, size_t len) {
     fullDate_ = FullDate::fromRaw(str, len);
 }


### PR DESCRIPTION
This is exactly #102 but old was on my master forked branch. And I messed that branch up.

Pass tests:
- gcc version 7.1.1 20170528 (GCC) (glibc)
- gcc version 6.3.0 (GCC) (musl)

Require:
-gcc >= 5.1 