### PR TITLE
Add operator!= for MediaType

### DIFF
--- a/include/pistache/mime.h
+++ b/include/pistache/mime.h
@@ -211,6 +211,10 @@ inline bool operator==(const MediaType& lhs, const MediaType& rhs) {
            lhs.suffix() == rhs.suffix();
 }
 
+inline bool operator!=(const MediaType& lhs, const MediaType& rhs){
+    return !operator==(lhs, rhs);
+}
+
 } // namespace Mime
 } // namespace Http
 } // namespace Pistache


### PR DESCRIPTION
Just add function for cmp MediaTypes to avoid  `!((MediaType)m1 == (MediaType)m2)`