### PR TITLE
Add application/octet-stream to be type-safe

### DIFF
--- a/include/pistache/mime.h
+++ b/include/pistache/mime.h
@@ -36,6 +36,7 @@ namespace Mime {
     SUB_TYPE(Javascript, "javascript") \
     SUB_TYPE(Css       , "css")        \
     \
+    SUB_TYPE(OctetStream,    "octet-stream") \
     SUB_TYPE(Json          , "json")                  \
     SUB_TYPE(FormUrlEncoded, "x-www-form-urlencoded") \
     \

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -671,16 +671,16 @@ serveFile(ResponseWriter& response, const char* fileName, const Mime::MediaType&
 
     int fd = open(fileName, O_RDONLY);
     if (fd == -1) {
-        if(errno == ENOENT)
-            throw HttpError(Http::Code::Not_Found, "");
+        std::string str_error(strerror(errno));
+        if(errno == ENOENT) {
+            throw HttpError(Http::Code::Not_Found, std::move(str_error));
+        }
         //eles if TODO 
         /* @Improvement: maybe could we check for errno here and emit a different error
             message
         */
-        else
-        {
-            std::string str_error(strerror(errno));
-            HttpError(Http::Code::Internal_Server_Error, str_error);
+        else {
+            throw HttpError(Http::Code::Internal_Server_Error, std::move(str_error));
         }
     }
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -671,10 +671,17 @@ serveFile(ResponseWriter& response, const char* fileName, const Mime::MediaType&
 
     int fd = open(fileName, O_RDONLY);
     if (fd == -1) {
+        if(errno == ENOENT)
+            throw HttpError(Http::Code::Not_Found, "");
+        //eles if TODO 
         /* @Improvement: maybe could we check for errno here and emit a different error
             message
         */
-        throw HttpError(Http::Code::Not_Found, "");
+        else
+        {
+            std::string str_error(strerror(errno));
+            HttpError(Http::Code::Internal_Server_Error, str_error);
+        }
     }
 
     int res = ::fstat(fd, &sb);

--- a/src/common/mime.cc
+++ b/src/common/mime.cc
@@ -82,7 +82,9 @@ MediaType::fromFile(const char* fileName)
         { "bmp", Type::Image, Subtype::Bmp },
 
         { "txt", Type::Text, Subtype::Plain },
-        { "md", Type::Text, Subtype::Plain }
+        { "md", Type::Text, Subtype::Plain },
+
+        { "bin", Type::Application, Subtype::OctetStream},
     };
 
     for (const auto& ext: KnownExtensions) {


### PR DESCRIPTION
Start here https://github.com/oktal/pistache/blob/b66415aaa0dc443b7874acbbb488058b34c2dc01/src/common/http.cc#L710 :
```
auto mime = Mime::MediaType::fromFile(fileName);
        if (mime.isValid())
            setContentType(mime);
```
If we don't know what this file is we can always use application/octet-stream?! 