### PR TITLE
added an overlaod for match_string

### DIFF
--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -308,6 +308,12 @@ enum class CaseSensitivity {
 bool match_raw(const void* buf, size_t len, StreamCursor& cursor);
 bool match_string(const char *str, size_t len, StreamCursor& cursor,
         CaseSensitivity cs = CaseSensitivity::Insensitive);
+template<size_t N>
+bool match_string(const char (&str)[N], StreamCursor& cursor,
+        CaseSensitivity cs = CaseSensitivity::Insensitive) {
+    return match_string(str, N - 1, cursor, cs);
+}
+
 bool match_literal(char c, StreamCursor& cursor, CaseSensitivity cs = CaseSensitivity::Insensitive);
 bool match_until(char c, StreamCursor& cursor, CaseSensitivity cs = CaseSensitivity::Insensitive);
 bool match_until(std::initializer_list<char> chars, StreamCursor& cursor, CaseSensitivity cs = CaseSensitivity::Insensitive);

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -34,8 +34,8 @@ namespace
         RawStreamBuf<char> buf(const_cast<char *>(&url[0]), url.size());
         StreamCursor cursor(&buf);
 
-        match_string("http://", std::strlen("http://"), cursor);
-        match_string("www", std::strlen("www"), cursor);
+        match_string("http://", cursor);
+        match_string("www", cursor);
         match_literal('.', cursor);
 
         StreamCursor::Token hostToken(cursor);

--- a/src/common/http_header.cc
+++ b/src/common/http_header.cc
@@ -257,13 +257,10 @@ Connection::parseRaw(const char* str, size_t len) {
     RawStreamBuf<> buf(p, p + len);
     StreamCursor cursor(&buf);
 
-#define STR(str) \
-    str, sizeof(str) - 1
-
-    if (match_string(STR("close"), cursor)) {
+    if (match_string("close", cursor)) {
         control_ = ConnectionControl::Close;
     }
-    else if (match_string(STR("keep-alive"), cursor)) {
+    else if (match_string("keep-alive", cursor)) {
         control_ = ConnectionControl::KeepAlive;
     }
     else {


### PR DESCRIPTION
This change makes it simpler to deduce string length when it's possible and void a macro.