### PR TITLE
Add versionString function at http_defs.h header file

### DIFF
--- a/include/pistache/http_defs.h
+++ b/include/pistache/http_defs.h
@@ -175,6 +175,7 @@ private:
 };
 
 const char* methodString(Method method);
+const char* versionString(Version version);
 const char* codeString(Code code);
 
 std::ostream& operator<<(std::ostream& os, Version version);


### PR DESCRIPTION
Hi,

The function ```versionString()``` is defined at ```http_defs.cc``` but is not available for use through the ```http_defs.h``` header file. 

My personal use case with ```versionString()``` is for logging purpose.

Regards.