### PR TITLE
Avoid race condition when handling timer timeouts

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -209,7 +209,6 @@ public:
             [=](uint64_t numWakeup) {
                 this->armed = false;
                 this->onTimeout(numWakeup);
-                close(timerFd);
         },
         [=](std::exception_ptr exc) {
             std::rethrow_exception(exc);

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -83,6 +83,7 @@ Transport::onReady(const Aio::FdSet& fds) {
                 auto& entry = it->second;
                 handleTimer(std::move(entry));
                 timers.erase(it);
+		close(entry.fd);
             }
             else {
                 throw std::runtime_error("Unknown fd");


### PR DESCRIPTION
When using timeouts:
e.g.: response.timeoutAfter(std::chrono::milliseconds(100));
we get sometimes timer already armed error followed by a SEGV+core dump (running run_http_server)

The problem is apparently due to a race condition between the time the timerfd is closed, and the time it is erased from the timers map.

The timerfd is first closed, and then erased from the map,
If we have the following sequence a problem can happen (it happens almost every time in my tests when load gets a bit high)
e.g.:
thread 1 close(timerfd) (http.h:) around line 210
thread 2 void arm(Duration duration) { (http.h)
Async::Promise<uint64_t> p([=](Async::Deferred<uint64_t> deferred) {
timerFd = TRY_RET(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));

it reuses the closed the timerfd
thread 1: timers.erase(it) (transport.cc line 85)

We should actually close the timerfd only after doing timers.erase(it)

