### PR TITLE
Query in client

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -97,12 +97,14 @@ namespace Uri {
         void add(std::string name, std::string value);
         Optional<std::string> get(const std::string& name) const;
         bool has(const std::string& name) const;
-
+        std::string str() const; // For Pistache::Client allow to easy genarete page url!
+        
         void clear() {
             params.clear();
         }
 
     private:
+        //first is key second is value
         std::unordered_map<std::string, std::string> params;
     };
 } // namespace Uri

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -87,7 +87,6 @@ protected:
 };
 
 namespace Uri {
-    typedef std::string Fragment;
 
     class Query {
     public:

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -96,7 +96,8 @@ namespace Uri {
         void add(std::string name, std::string value);
         Optional<std::string> get(const std::string& name) const;
         bool has(const std::string& name) const;
-        std::string str() const; // For Pistache::Client allow to easy genarete page url!
+        // Return empty string or "?key1=value1&key2=value2" if query exist
+        std::string as_str() const;
         
         void clear() {
             params.clear();

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -500,6 +500,16 @@ namespace Uri {
 
         return Some(it->second);
     }
+    
+    std::string 
+    Query::str() const {
+        std::string query_url;
+        for(const auto &e : params)
+            query_url += "&" + e.first + "=" + e.second;
+        if(not query_url.empty()) // if is not empty
+            query_url[0] = '?';
+        return query_url;
+    }
 
     bool
     Query::has(const std::string& name) const {

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -502,12 +502,14 @@ namespace Uri {
     }
     
     std::string 
-    Query::str() const {
+    Query::as_str() const {
         std::string query_url;
-        for(const auto &e : params)
+        for(const auto &e : params) {
             query_url += "&" + e.first + "=" + e.second;
-        if(not query_url.empty()) // if is not empty
-            query_url[0] = '?';
+        }
+        if(not query_url.empty()) {
+            query_url[0] = '?'; // replace first `&` with `?`
+        } else {/* query_url is empty */}
         return query_url;
     }
 


### PR DESCRIPTION
The query is only defined for Server purpose. I added ~`str()`~ `as_str()` method that generate part of url.

U can now create a own Clinet Wraper for some API with easy query parametes (they can by create from initialization list).

If sb has idea how make them compile-time safe in client form don't hesitate.