### PR TITLE
Getting rid of compiler warnings about initialization order

### DIFF
--- a/include/pistache/async.h
+++ b/include/pistache/async.h
@@ -1,6 +1,6 @@
 /* async.h
    Mathieu Stefani, 05 novembre 2015
-   
+
   This header brings a Promise<T> class inspired by the Promises/A+
   specification for asynchronous operations
 */
@@ -253,9 +253,9 @@ namespace Async {
         template<typename T>
         struct Continuable : public Request {
             Continuable(const std::shared_ptr<Core>& chain)
-                : chain_(chain)
-                , resolveCount_(0)
+                : resolveCount_(0)
                 , rejectCount_(0)
+                , chain_(chain)
             { }
 
             void resolve(const std::shared_ptr<Core>& core) {
@@ -722,7 +722,7 @@ namespace Async {
         Resolver& operator=(const Resolver& other) = delete;
 
         Resolver(Resolver&& other) = default;
-        Resolver& operator=(Resolver&& other) = default; 
+        Resolver& operator=(Resolver&& other) = default;
 
         template<typename Arg>
         bool operator()(Arg&& arg) const {
@@ -947,7 +947,7 @@ namespace Async {
             : core_(std::make_shared<Core>())
             , resolver_(core_)
             , rejection_(core_)
-        { 
+        {
             details::callAsync<T>(func, resolver_, rejection_);
         }
 

--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -1,6 +1,6 @@
-/* 
+/*
    Mathieu Stefani, 29 janvier 2016
-   
+
    The Http client
 */
 
@@ -34,9 +34,9 @@ struct Connection : public std::enable_shared_from_this<Connection> {
 
     Connection()
         : fd(-1)
-        , connectionState_(NotConnected)
         , inflightCount(0)
         , responsesReceived(0)
+        , connectionState_(NotConnected)
     {
         state_.store(static_cast<uint32_t>(State::Idle));
     }
@@ -51,7 +51,7 @@ struct Connection : public std::enable_shared_from_this<Connection> {
             : resolve(std::move(resolve))
             , reject(std::move(reject))
             , request(request)
-            , timeout(timeout)  
+            , timeout(timeout)
             , onDone(std::move(onDone))
         { }
         Async::Resolver resolve;

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -1,6 +1,6 @@
 /* http.h
    Mathieu Stefani, 13 August 2015
-   
+
    Http Layer
 */
 
@@ -140,7 +140,7 @@ public:
         drop of 5x with that lock
 
         If this turns out to be a problem, we might be able to replace the weak_ptr
-        trick to detect peer disconnection by a plain old "observer" pointer to a 
+        trick to detect peer disconnection by a plain old "observer" pointer to a
         tcp connection with a "stale" state
     */
 #ifdef LIBSTDCPP_SMARTPTR_LOCK_FIXME
@@ -230,9 +230,9 @@ public:
 
 private:
     Timeout(const Timeout& other)
-        : transport(other.transport)
-        , handler(other.handler)
+        : handler(other.handler)
         , request(other.request)
+        , transport(other.transport)
         , armed(other.armed)
         , timerFd(other.timerFd)
     { }
@@ -240,9 +240,9 @@ private:
     Timeout(Tcp::Transport* transport,
             Handler* handler,
             Request request)
-        : transport(transport)
-        , handler(handler)
+        : handler(handler)
         , request(std::move(request))
+        , transport(transport)
         , armed(false)
         , timerFd(-1)
     {
@@ -531,7 +531,7 @@ private:
         : Response(request.version())
         , buf_(DefaultStreamSize)
         , transport_(transport)
-        , timeout_(transport, handler, std::move(request)) 
+        , timeout_(transport, handler, std::move(request))
     { }
 
     ResponseWriter(const ResponseWriter& other)
@@ -651,14 +651,14 @@ namespace Private {
 
     struct ParserBase {
         ParserBase()
-            : currentStep(0)
-            , cursor(&buffer)
+            : cursor(&buffer)
+            , currentStep(0)
         {
         }
 
         ParserBase(const char* data, size_t len)
-            : currentStep(0)
-            , cursor(&buffer)
+            : cursor(&buffer)
+            , currentStep(0)
         {
         }
 
@@ -686,7 +686,7 @@ namespace Private {
     template<> struct Parser<Http::Request> : public ParserBase {
         Parser()
             : ParserBase()
-        { 
+        {
             allSteps[0].reset(new RequestLineStep(&request));
             allSteps[1].reset(new HeadersStep(&request));
             allSteps[2].reset(new BodyStep(&request));

--- a/include/pistache/transport.h
+++ b/include/pistache/transport.h
@@ -1,6 +1,6 @@
-/* 
+/*
    Mathieu Stefani, 26 janvier 2016
-   
+
    Transport TCP layer
 */
 
@@ -88,16 +88,16 @@ private:
         enum Type { Raw, File };
 
         explicit BufferHolder(const Buffer& buffer, off_t offset = 0)
-            : type(Raw)
-            , u(buffer)
+            : u(buffer)
+            , type(Raw)
         {
             offset_ = offset;
             size_ = buffer.len;
         }
 
         explicit BufferHolder(const FileBuffer& buffer, off_t offset = 0)
-            : type(File)
-            , u(buffer.fd())
+            : u(buffer.fd())
+            , type(File)
         {
             offset_ = offset;
             size_ = buffer.size();


### PR DESCRIPTION
Good work on this package!
This PR is pretty trivial, only getting rid of compiler warnings about initialization order.