### PR TITLE
Dynamic buffer size on headers and request body. Ability to use raw headers in return request. Access IP address of request sender

### DIFF
--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -732,11 +732,9 @@ serveFile(ResponseWriter& response, const char* fileName, const Mime::MediaType&
 void
 Handler::onInput(const char* buffer, size_t len, const std::shared_ptr<Tcp::Peer>& peer) {
     auto& parser = getParser(peer);
+    parser.request.addr_ = peer->address();
     try {
-        if (!parser.feed(buffer, len)) {
-            parser.reset();
-            throw HttpError(Code::Request_Entity_Too_Large, "Request exceeded maximum buffer size");
-        }
+        parser.feed(buffer, len);
 
         auto state = parser.parse();
         if (state == Private::State::Done) {

--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -170,6 +170,17 @@ Collection::list() const {
     return ret;
 }
 
+std::vector<Raw>
+Collection::rawlist() const {
+    std::vector<Raw> ret;
+    ret.reserve(rawHeaders.size());
+    for (const auto& h: rawHeaders) {
+        ret.push_back(h.second);
+    }
+
+    return ret;
+}
+
 bool
 Collection::remove(const std::string& name) {
     auto tit = headers.find(name);

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -104,6 +104,12 @@ Address::port() const {
 }
 
 void
+Address::clear()
+{
+    host_.clear();
+}
+
+void
 Address::init(std::string addr) {
     auto pos = addr.find(':');
 


### PR DESCRIPTION
Dynamic buffer size on headers and request body. Starts at 2000 bytes then increments by 40% until the buffer is large enough to acomadate the data.

Ability to use raw headers in return request. Access IP address of request sender