### PR TITLE
Simple update to the README.md to include build info 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,43 @@ Full documentation is located at [http://pistache.io](http://pistache.io).
 
 Pistache is an open-source project and will always stay open-source. However, working on an open-source project while having a full-time job is sometimes a difficult task to accomplish.
 
-That's why your help is needed. If you would like to contribute to the project in any way (submitting ideas, fixing bugs, writing documentation, ...), please join the 
+That's why your help is needed. If you would like to contribute to the project in any way (submitting ideas, fixing bugs, writing documentation, ...), please join the
 [cpplang Slack channel](https://cpplang.now.sh/). Drop a private message to `@octal` and I will invite you to the channel dedicated to Pistache.
 
 Hope to see you there !
+
+# To Build:
+
+To download the latest available release, clone the repository over github.
+
+git clone https://github.com/oktal/pistache.git
+
+Then, init the submodules:
+
+git submodule update --init
+
+Now, compile the sources:
+
+    cd pistache
+    mkdir build
+    cd build
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+    make
+    sudo make install
+
+If you want the examples built, then change change the cmake above to:
+
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCPISTACHE_BUILD_EXAMPLES=true    ..
+
+After running the above, you can then cd into the build/examples directory and run make.
+
+Optionally, you can also run the tests:
+
+    make test
+
+Be patient, async_test can take some time before completing.
+
+And that’s it, now you can start playing with your newly installed Pistache framework.
 
 # Example
 


### PR DESCRIPTION
This is a simple update to the README.md to include build info plus notes for building the examples. Most of the notes are from the Getting Started document, but having it in the README.md makes it easier to find.