### PR TITLE
Exit after closeListener() when handling SIGINT

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -40,8 +40,9 @@ namespace {
         }
     }
 
-    void handle_sigint(int) {
+    void handle_sigint(int signum) {
         closeListener();
+        exit(signum);
     }
 }
 


### PR DESCRIPTION
Allows the http_server example to exit on <kbd>Ctrl-c</kbd> as well as clean up properly.

It doesn't seem to make sense to close the `fd` created in `Listener::bind(const Address& address)` and then sit there, unbound, but not exiting.

Thoughts or concerns?