### PR TITLE
Allow access to unknown and arbitrary raw headers

### DIFF
--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -104,6 +104,10 @@ public:
 
     std::vector<std::shared_ptr<Header>> list() const;
 
+    const std::unordered_map<std::string, Raw>& rawList() const {
+        return rawHeaders;
+    }
+
     bool remove(const std::string& name);
 
     void clear();


### PR DESCRIPTION
It may happen that the headers are not know in advance. One possible
scenario is that the caller provide a bunch of arbitrary headers with a
predefined prefix, acting as customer metadata, that the applications
needs to store somewhere for later reuse, in responses for example.

Those arbitrary might be used by the customer for many purposes, like
custom load-balancing or particular routing.