### PR TITLE
Add cmake Setup Instructions For make test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ Now, compile the sources:
 
 If you want the examples built, then change change the cmake above to:
 
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCPISTACHE_BUILD_EXAMPLES=true    ..
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCPISTACHE_BUILD_EXAMPLES=true ..
 
 After running the above, you can then cd into the build/examples directory and run make.
 
-Optionally, you can also run the tests:
+Optionally, you can also build and run the tests:
 
+    cmake -G "Unix Makefiles" -DPISTACHE_BUILD_TESTS=true ..
     make test
 
 Be patient, async_test can take some time before completing.


### PR DESCRIPTION
make test will not work without first enabling the build of the tests.
The README.md documentation was not updated when the change that
requires the variable be enabled (863eba92) was pushed.

This resolves part of Issue #249 in that with it in place and clean
working directory the tests will compile and run.

It is probably not enough to consider #249 complete at present as all of
the test fail on my system, suggesting something is grossly wrong.