### PR TITLE
Fix undefined behaviour in copy assignment operator

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -552,6 +552,7 @@ struct MoveOnCopy {
 
     MoveOnCopy& operator=(MoveOnCopy& other) {
         val = std::move(other.val);
+        return *this;
     }
 
     MoveOnCopy(MoveOnCopy&& other) = default;


### PR DESCRIPTION
In this PR I'm fixing undefined behaviour in copy assignment operator: forgotten return value