### PR TITLE
Fix Request Cookies Parsing

### DIFF
--- a/include/pistache/cookie.h
+++ b/include/pistache/cookie.h
@@ -78,6 +78,7 @@ public:
     CookieJar();
 
     void add(const Cookie& cookie);
+    void addFromRaw(const char *str, size_t len);
     Cookie get(const std::string& name) const;
 
     bool has(const std::string& name) const;

--- a/src/common/cookie.cc
+++ b/src/common/cookie.cc
@@ -212,32 +212,32 @@ CookieJar::add(const Cookie& cookie) {
 
 void
 CookieJar::addFromRaw(const char *str, size_t len) {
-	RawStreamBuf<> buf(const_cast<char *>(str), len);
-	StreamCursor cursor(&buf);
+    RawStreamBuf<> buf(const_cast<char *>(str), len);
+    StreamCursor cursor(&buf);
 
-	while (!cursor.eof()) {
-		StreamCursor::Token nameToken(cursor);
-		
-		if (!match_until('=', cursor))
-			throw std::runtime_error("Invalid cookie, missing value");
-		
-		auto name = nameToken.text();
-		
-		if (!cursor.advance(1))
-			throw std::runtime_error("Invalid cookie, missing value");
-		
-		StreamCursor::Token valueToken(cursor);
-		
-		match_until(';', cursor);
-		auto value = valueToken.text();
-		
-		Cookie cookie(std::move(name), std::move(value));
-		add(cookie);
-		
-		cursor.advance(1);
-		skip_whitespaces(cursor);
-	}
-}	
+    while (!cursor.eof()) {
+        StreamCursor::Token nameToken(cursor);
+
+        if (!match_until('=', cursor))
+            throw std::runtime_error("Invalid cookie, missing value");
+
+        auto name = nameToken.text();
+
+        if (!cursor.advance(1))
+            throw std::runtime_error("Invalid cookie, missing value");
+
+        StreamCursor::Token valueToken(cursor);
+
+        match_until(';', cursor);
+        auto value = valueToken.text();
+
+        Cookie cookie(std::move(name), std::move(value));
+        add(cookie);
+
+        cursor.advance(1);
+        skip_whitespaces(cursor);
+    }
+}       
 
 Cookie
 CookieJar::get(const std::string& name) const {

--- a/src/common/cookie.cc
+++ b/src/common/cookie.cc
@@ -234,7 +234,8 @@ CookieJar::addFromRaw(const char *str, size_t len) {
 		Cookie cookie(std::move(name), std::move(value));
 		add(cookie);
 		
-		cursor.advance(2);
+		cursor.advance(1);
+		skip_whitespaces(cursor);
 	}
 }	
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -294,9 +294,7 @@ namespace Private {
             }
 
             if (name == "Cookie") {
-                message->cookies_.add(
-                        Cookie::fromRaw(cursor.offset(start), cursor.diff(start))
-                );
+		message->cookies_.addFromRaw(cursor.offset(start), cursor.diff(start));
             }
 
             else if (Header::Registry::isRegistered(name)) {

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -294,7 +294,7 @@ namespace Private {
             }
 
             if (name == "Cookie") {
-		message->cookies_.addFromRaw(cursor.offset(start), cursor.diff(start));
+                message->cookies_.addFromRaw(cursor.offset(start), cursor.diff(start));
             }
 
             else if (Header::Registry::isRegistered(name)) {

--- a/tests/cookie_test.cc
+++ b/tests/cookie_test.cc
@@ -137,14 +137,14 @@ void addCookies(const char* str, std::function<void (const CookieJar&)> testFunc
 
 TEST(cookie_test, cookiejar_test) {
     addCookies("key1=value1", [](const CookieJar& jar) {
-	ASSERT_EQ(jar.get("key1").value, "value1");
+        ASSERT_EQ(jar.get("key1").value, "value1");
     });
-    
+
     addCookies("key2=value2; key3=value3", [](const CookieJar& jar) {
-	ASSERT_EQ(jar.get("key2").value, "value2");
-	ASSERT_EQ(jar.get("key3").value, "value3");
+        ASSERT_EQ(jar.get("key2").value, "value2");
+        ASSERT_EQ(jar.get("key3").value, "value3");
     });
-    
+
     CookieJar jar;
     ASSERT_THROW(jar.addFromRaw("key4", strlen("key4")), std::runtime_error);
 }

--- a/tests/cookie_test.cc
+++ b/tests/cookie_test.cc
@@ -129,3 +129,22 @@ TEST(cookie_test, invalid_test) {
     ASSERT_THROW(Cookie::fromString("lang=en-US; Max-Age=12ab"), std::invalid_argument);
 }
 
+void addCookies(const char* str, std::function<void (const CookieJar&)> testFunc) {
+    CookieJar jar;
+    jar.addFromRaw(str, strlen(str));
+    testFunc(jar);
+}
+
+TEST(cookie_test, cookiejar_test) {
+    addCookies("key1=value1", [](const CookieJar& jar) {
+	ASSERT_EQ(jar.get("key1").value, "value1");
+    });
+    
+    addCookies("key2=value2; key3=value3", [](const CookieJar& jar) {
+	ASSERT_EQ(jar.get("key2").value, "value2");
+	ASSERT_EQ(jar.get("key3").value, "value3");
+    });
+    
+    CookieJar jar;
+    ASSERT_THROW(jar.addFromRaw("key4", strlen("key4")), std::runtime_error);
+}


### PR DESCRIPTION
Fixes the parsing of the "Cookie" header of a request by implementing an "addFromRaw" method that adds cookies to a CookieJar directly from the header string. (Issue #265) 