### PR TITLE
Improve memory management using shared_ptr instead of raw pointer

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -342,7 +342,7 @@ private:
    typedef std::lock_guard<Lock> Guard;
 
    Lock queuesLock;
-   std::unordered_map<std::string, MPMCQueue<Connection::RequestData *, 2048>> requestsQueues;
+   std::unordered_map<std::string, MPMCQueue<std::shared_ptr<Connection::RequestData>, 2048>> requestsQueues;
 
    RequestBuilder prepareRequest(std::string resource, Http::Method method);
 


### PR DESCRIPTION
In this pull request I propose to use `shared_ptr` instead of raw pointer to manage `Connection::RequestData` in `requestsQueues`. As a result you don't need to delete resource manually and worry about cleaning memory in case of expection.