### PR TITLE
Fix perfomance issue: redundant strings copying

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -257,7 +257,7 @@ public:
     friend class Client;
 
     RequestBuilder& method(Method method);
-    RequestBuilder& resource(std::string val);
+    RequestBuilder& resource(const std::string& val);
     RequestBuilder& params(const Uri::Query& query);
     RequestBuilder& header(const std::shared_ptr<Header::Header>& header);
 
@@ -321,11 +321,11 @@ public:
    static Options options();
    void init(const Options& options);
 
-   RequestBuilder get(std::string resource);
-   RequestBuilder post(std::string resource);
-   RequestBuilder put(std::string resource);
-   RequestBuilder patch(std::string resource);
-   RequestBuilder del(std::string resource);
+   RequestBuilder get(const std::string& resource);
+   RequestBuilder post(const std::string& resource);
+   RequestBuilder put(const std::string& resource);
+   RequestBuilder patch(const std::string& resource);
+   RequestBuilder del(const std::string& resource);
 
    void shutdown();
 
@@ -344,7 +344,7 @@ private:
    Lock queuesLock;
    std::unordered_map<std::string, MPMCQueue<std::shared_ptr<Connection::RequestData>, 2048>> requestsQueues;
 
-   RequestBuilder prepareRequest(std::string resource, Http::Method method);
+   RequestBuilder prepareRequest(const std::string& resource, Http::Method method);
 
    Async::Promise<Response> doRequest(
            Http::Request req,

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -710,8 +710,8 @@ RequestBuilder::method(Method method)
 }
 
 RequestBuilder&
-RequestBuilder::resource(std::string val) {
-    request_.resource_ = std::move(val);
+RequestBuilder::resource(const std::string& val) {
+    request_.resource_ = val;
     return *this;
 }
 
@@ -791,41 +791,41 @@ Client::shutdown() {
 }
 
 RequestBuilder
-Client::get(std::string resource)
+Client::get(const std::string& resource)
 {
-    return prepareRequest(std::move(resource), Http::Method::Get);
+    return prepareRequest(resource, Http::Method::Get);
 }
 
 RequestBuilder
-Client::post(std::string resource)
+Client::post(const std::string& resource)
 {
-    return prepareRequest(std::move(resource), Http::Method::Post);
+    return prepareRequest(resource, Http::Method::Post);
 }
 
 RequestBuilder
-Client::put(std::string resource)
+Client::put(const std::string& resource)
 {
-    return prepareRequest(std::move(resource), Http::Method::Put);
+    return prepareRequest(resource, Http::Method::Put);
 }
 
 RequestBuilder
-Client::patch(std::string resource)
+Client::patch(const std::string& resource)
 {
-    return prepareRequest(std::move(resource), Http::Method::Patch);
+    return prepareRequest(resource, Http::Method::Patch);
 }
 
 RequestBuilder
-Client::del(std::string resource)
+Client::del(const std::string& resource)
 {
-    return prepareRequest(std::move(resource), Http::Method::Delete);
+    return prepareRequest(resource, Http::Method::Delete);
 }
 
 RequestBuilder
-Client::prepareRequest(std::string resource, Http::Method method)
+Client::prepareRequest(const std::string& resource, Http::Method method)
 {
     RequestBuilder builder(this);
     builder
-        .resource(std::move(resource))
+        .resource(resource)
         .method(method);
 
     return builder;


### PR DESCRIPTION
In this PR I'm fixing redundant strings copying in `Client` class. It would be better to pass resource name by `const std::string&` instread of creating a lot of template object during chain of calls. You can do perfomance tests with passing plenty of strings to `get` method and see the result.