### PR TITLE
Stream write

### DIFF
--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -121,6 +121,16 @@ class MyHandler : public Http::Handler {
                 response.send(Http::Code::Method_Not_Allowed);
             }
         }
+        else if (req.resource() == "/stream_binary") {
+            auto stream = response.stream(Http::Code::Ok);
+            char binary_data[] = "some \0\r\n data\n";
+            size_t chunk_size = 14;
+            for (size_t i = 0; i < 10; ++i) {
+                stream.write(binary_data, chunk_size);
+                stream.flush();
+            }
+            stream.ends();
+        }
         else if (req.resource() == "/exception") {
             throw std::runtime_error("Exception thrown in the handler");
         }

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -316,6 +316,14 @@ public:
     friend
     ResponseStream& operator<<(ResponseStream& stream, const T& val);
 
+    std::streamsize write(char * data, std::streamsize sz) {
+        std::ostream os(&buf_);
+        os << std::hex << sz << crlf;
+        os.write(data, sz);
+        os << crlf;
+        return sz;
+    }
+
     const Header::Collection& headers() const {
         return headers_;
     }

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -100,7 +100,7 @@ namespace Uri {
         bool has(const std::string& name) const;
         // Return empty string or "?key1=value1&key2=value2" if query exist
         std::string as_str() const;
-        
+
         void clear() {
             params.clear();
         }
@@ -321,6 +321,7 @@ public:
         os << std::hex << sz << crlf;
         os.write(data, sz);
         os << crlf;
+        flush();
         return sz;
     }
 
@@ -377,6 +378,7 @@ ResponseStream& operator<<(ResponseStream& stream, const T& val) {
     std::ostream os(&stream.buf_);
     os << std::hex << size(val) << crlf;
     os << val << crlf;
+    stream.flush();
 
     return stream;
 }

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -321,7 +321,6 @@ public:
         os << std::hex << sz << crlf;
         os.write(data, sz);
         os << crlf;
-        flush();
         return sz;
     }
 
@@ -378,7 +377,6 @@ ResponseStream& operator<<(ResponseStream& stream, const T& val) {
     std::ostream os(&stream.buf_);
     os << std::hex << size(val) << crlf;
     os << val << crlf;
-    stream.flush();
 
     return stream;
 }

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -316,7 +316,7 @@ public:
     friend
     ResponseStream& operator<<(ResponseStream& stream, const T& val);
 
-    std::streamsize write(char * data, std::streamsize sz) {
+    std::streamsize write(const char * data, std::streamsize sz) {
         std::ostream os(&buf_);
         os << std::hex << sz << crlf;
         os.write(data, sz);


### PR DESCRIPTION
Adds a `ResponseStream::write(char *, std::streamsize)` method, which is helpful for sending chunked binary data (e.g. large gzip'd responses).

Also adds a `/stream_binary` example path to the run_http_server to show the write() call in action.