### PR TITLE
fix building on clang 6.0

### DIFF
--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -5,6 +5,7 @@
 */
 
 #include <pistache/reactor.h>
+#include <array>
 
 namespace Pistache {
 namespace Aio {


### PR DESCRIPTION
Hello,

I tried to compile the project with C++17 and clang 6.0. I got an include error. I fixed. Please merge.

Br:
Antal Tatrai