### PR TITLE
Added Access-Control-Allow-Headers to the set of headers

### DIFF
--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -57,7 +57,7 @@ namespace Const {
 
     static constexpr int MaxBacklog = 128;
     static constexpr int MaxEvents = 1024;
-    static constexpr int MaxBuffer = 4096*1024;
+    static constexpr int MaxBuffer = 4096;
     static constexpr int ChunkSize = 1024;
 } // namespace Const
 } // namespace Pistache

--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -57,7 +57,7 @@ namespace Const {
 
     static constexpr int MaxBacklog = 128;
     static constexpr int MaxEvents = 1024;
-    static constexpr int MaxBuffer = 4096;
+    static constexpr int MaxBuffer = 4096*1024;
     static constexpr int ChunkSize = 1024;
 } // namespace Const
 } // namespace Pistache

--- a/include/pistache/http_header.h
+++ b/include/pistache/http_header.h
@@ -186,6 +186,32 @@ private:
   std::string uri_;
 };
 
+class AccessControlAllowHeaders : public Header {
+public:
+  NAME("Access-Control-Allow-Headers")
+
+  AccessControlAllowHeaders() { }
+
+  explicit AccessControlAllowHeaders(const char* val)
+    : val_(val)
+  { }
+  explicit AccessControlAllowHeaders(const std::string& val)
+    : val_(val)
+  { }
+
+  void parse(const std::string& data);
+  void write(std::ostream& os) const;
+
+  void setUri(std::string val) {
+    val_ = std::move(val);
+  }
+
+  std::string val() const { return val_; }
+
+private:
+  std::string val_;
+};
+
 class CacheControl : public Header {
 public:
     NAME("Cache-Control")

--- a/src/common/http_header.cc
+++ b/src/common/http_header.cc
@@ -433,6 +433,16 @@ AccessControlAllowOrigin::write(std::ostream& os) const {
 }
 
 void
+AccessControlAllowHeaders::parse(const std::string& data) {
+  val_ = data;
+}
+
+void
+AccessControlAllowHeaders::write(std::ostream& os) const {
+  os << val_;
+}
+
+void
 EncodingHeader::parseRaw(const char* str, size_t len) {
     if (!strncasecmp(str, "gzip", len)) {
         encoding_ = Encoding::Gzip;

--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -26,6 +26,7 @@ namespace {
 
 RegisterHeader(Accept);
 RegisterHeader(AccessControlAllowOrigin);
+RegisterHeader(AccessControlAllowHeaders);
 RegisterHeader(Allow);
 RegisterHeader(CacheControl);
 RegisterHeader(Connection);

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -278,3 +278,11 @@ TEST(headers_test, access_control_allow_origin_test)
     allowOrigin.parse("http://foo.bar");
     ASSERT_EQ(allowOrigin.uri(), "http://foo.bar");
 }
+
+TEST(headers_test, access_control_allow_headers_test)
+{
+    Header::AccessControlAllowHeaders allowHeaders;
+
+    allowHeaders.parse("Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+    ASSERT_EQ(allowHeaders.val(), "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+}


### PR DESCRIPTION
Added Access-Control-Allow-Headers to the set of headers.
This is needed when calling endpoint from JavaScript in a browser, otherwise we run into an error in the OPTIONS request.
 