### PR TITLE
Code refactoring: move port value convertion to string to Port class

### DIFF
--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -34,6 +34,7 @@ public:
 
     bool isReserved() const;
     bool isUsed() const;
+    std::string toString() const;
 
     static constexpr uint16_t min() {
         return std::numeric_limits<uint16_t>::min();

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -384,16 +384,9 @@ Connection::connect(Address addr)
     hints.ai_flags = 0;
     hints.ai_protocol = 0;
 
-    auto host = addr.host();
-
-    /* We rely on the fact that a string literal is an lvalue const char[N] */
-    static constexpr size_t MaxPortLen = sizeof("65535");
-
-    char port[MaxPortLen];
-    std::fill(port, port + MaxPortLen, 0);
-    std::snprintf(port, MaxPortLen, "%d", static_cast<uint16_t>(addr.port()));
-
-    TRY(::getaddrinfo(host.c_str(), port, &hints, &addrs));
+    const auto& host = addr.host();
+    const auto& port = addr.port().toString();
+    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
 
     int sfd = -1;
 

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -33,6 +33,11 @@ Port::isUsed() const {
     return false;
 }
 
+std::string
+Port::toString() const {
+    return std::to_string(port);
+}
+
 Ipv4::Ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
     : a(a)
     , b(b)
@@ -111,6 +116,9 @@ Address::init(const std::string& addr) {
         throw std::invalid_argument("Invalid address");
 
     host_ = addr.substr(0, pos);
+    if (host_ == "*") {
+        host_ = "0.0.0.0";
+    }
 
     char *end;
     const std::string portPart = addr.substr(pos + 1);

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -153,20 +153,10 @@ Listener::bind(const Address& address) {
     hints.ai_flags = AI_PASSIVE;
     hints.ai_protocol = 0;
 
-    auto host = addr_.host();
-    if (host == "*") {
-        host = "0.0.0.0";
-    }
-
-    /* We rely on the fact that a string literal is an lvalue const char[N] */
-    static constexpr size_t MaxPortLen = sizeof("65535");
-
-    char port[MaxPortLen];
-    std::fill(port, port + MaxPortLen, 0);
-    std::snprintf(port, MaxPortLen, "%d", static_cast<uint16_t>(addr_.port()));
-
+    const auto& host = addr_.host();
+    const auto& port = addr_.port().toString();
     struct addrinfo *addrs;
-    TRY(::getaddrinfo(host.c_str(), port, &hints, &addrs));
+    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
 
     int fd = -1;
 

--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -17,11 +17,13 @@ TEST(net_test, port_creation)
     ASSERT_FALSE(port1.isReserved());
     uint16_t value1 = port1;
     ASSERT_EQ(value1, 3000);
+    ASSERT_EQ(port1.toString(), "3000");
 
     Port port2(80);
     ASSERT_TRUE(port2.isReserved());
     uint16_t value2 = port2;
     ASSERT_EQ(value2, 80);
+    ASSERT_EQ(port2.toString(), "80");
 }
 
 TEST(net_test, address_creation)
@@ -40,6 +42,10 @@ TEST(net_test, address_creation)
     ASSERT_EQ(address3.port(), 8080);    
 
     Address address4(Ipv4::any(), Port(8080));
+    ASSERT_EQ(address4.host(), "0.0.0.0");
+    ASSERT_EQ(address4.port(), 8080);
+
+    Address address5("*:8080");
     ASSERT_EQ(address4.host(), "0.0.0.0");
     ASSERT_EQ(address4.port(), 8080);
 }


### PR DESCRIPTION
In this PR I have moved port value convertion to `std::string` to `Port` class and implemented tests. Also I have moved `*` to `0.0.0.0` convertion to `Address::init`.