### PR TITLE
Fix memory leak 267 282

### DIFF
--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -53,6 +53,24 @@
 #define UNUSED(x) (void)(x);
 
 namespace Pistache {
+
+// RAII class for address info
+class AddressInfo {
+public:
+    AddressInfo(const char* host, const char* port,
+            const struct addrinfo& hints, struct addrinfo**addrs) {
+        addressInfo = addrs;
+        TRY(::getaddrinfo(host, port, &hints, addressInfo));
+    }
+
+    ~AddressInfo() {
+        freeaddrinfo(*addressInfo);
+    }
+
+private:
+    struct addrinfo **addressInfo;
+};
+
 namespace Const {
 
     static constexpr int MaxBacklog = 128;

--- a/include/pistache/mailbox.h
+++ b/include/pistache/mailbox.h
@@ -183,6 +183,7 @@ public:
 
     virtual ~Queue() {
         while (auto *e = pop()) delete e;
+        delete tail;
     }
 
     template<typename U>

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -386,7 +386,7 @@ Connection::connect(Address addr)
 
     const auto& host = addr.host();
     const auto& port = addr.port().toString();
-    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
+    AddressInfo addressInfo(host.c_str(), port.c_str(), hints, &addrs);
 
     int sfd = -1;
 

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -156,7 +156,7 @@ Listener::bind(const Address& address) {
     const auto& host = addr_.host();
     const auto& port = addr_.port().toString();
     struct addrinfo *addrs;
-    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
+    AddressInfo addressInfo(host.c_str(), port.c_str(), hints, &addrs);
 
     int fd = -1;
 

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -174,6 +174,7 @@ Listener::bind(const Address& address) {
         TRY(::listen(fd, backlog_));
         break;
     }
+    freeaddrinfo(addrs);
 
     make_non_blocking(fd);
     poller.addFd(fd, Polling::NotifyOn::Read, Polling::Tag(fd));

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -174,7 +174,6 @@ Listener::bind(const Address& address) {
         TRY(::listen(fd, backlog_));
         break;
     }
-    freeaddrinfo(addrs);
 
     make_non_blocking(fd);
     poller.addFd(fd, Polling::NotifyOn::Read, Polling::Tag(fd));


### PR DESCRIPTION
Issue #267:
   Freeing first element in the Queue constructor

Issue #282:
   Freeing allocated `addrs` structure after use.