### PR TITLE
Issue 302 - Fix listener_test

### DIFF
--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -116,6 +116,8 @@ TEST(listener_test, listener_bind_port_free) {
     Pistache::Address address(Pistache::Ipv4::any(), port);
 
     Pistache::Tcp::Listener listener;
+    Pistache::Flags<Pistache::Tcp::Options> options;
+    listener.init(1, options);
     listener.setHandler(Pistache::Http::make_handler<DummyHandler>());
     listener.bind(address);
     ASSERT_TRUE(true);
@@ -135,6 +137,8 @@ TEST(listener_test, listener_bind_port_not_free_throw_runtime) {
     Pistache::Address address(Pistache::Ipv4::any(), port);
 
     Pistache::Tcp::Listener listener;
+    Pistache::Flags<Pistache::Tcp::Options> options;
+    listener.init(1, options);
     listener.setHandler(Pistache::Http::make_handler<DummyHandler>());
 
     try {


### PR DESCRIPTION
If the listener::init, call is not present, the listener object will be in a state where its workers_ member is not initialized (size_t). In clang, this leads to the creation of an absurd number of threads which in turn
will make eventfd call fails in NotifyFd. See issue 302 for more details.