### PR TITLE
Initialize members of Listener with default value - Remove shared pointer 

### DIFF
--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -59,6 +59,7 @@ namespace Const {
     static constexpr size_t MaxBacklog = 128;
     static constexpr size_t MaxEvents  = 1024;
     static constexpr size_t MaxBuffer  = 4096;
+    static constexpr size_t DefaultWorkers = 1;
 
     // Defined from CMakeLists.txt in project root
     static constexpr size_t DefaultMaxPayload = 4096;

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -42,7 +42,7 @@ public:
     Listener();
     ~Listener();
 
-    Listener(const Address& address);
+    explicit Listener(const Address& address);
     void init(
             size_t workers,
             Flags<Options> options = Options::None,

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -80,7 +80,7 @@ private:
     std::shared_ptr<Transport> transport_;
     std::shared_ptr<Handler> handler_;
 
-    std::shared_ptr<Aio::Reactor> reactor_;
+    Aio::Reactor reactor_;
     Aio::Reactor::Key transportKey;
 
     void handleNewConnection();

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -74,16 +74,27 @@ void setSocketOptions(Fd fd, Flags<Options> options) {
 }
 
 Listener::Listener()
-    : listen_fd(-1)
+    : addr_()
+    , listen_fd(-1)
     , backlog_(Const::MaxBacklog)
+    , shutdownFd()
+    , poller()
+    , options_()
+    , workers_(Const::DefaultWorkers)
     , reactor_(Aio::Reactor::create())
+    , transportKey()
 { }
 
 Listener::Listener(const Address& address)
     : addr_(address)
     , listen_fd(-1)
     , backlog_(Const::MaxBacklog)
+    , shutdownFd()
+    , poller()
+    , options_()
+    , workers_(Const::DefaultWorkers)
     , reactor_(Aio::Reactor::create())
+    , transportKey()
 {
 }
 

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -123,6 +123,34 @@ TEST(listener_test, listener_bind_port_free) {
     ASSERT_TRUE(true);
 }
 
+// Listener should not crash if an additional member is added to the listener class. This test
+// is there to prevent regression for PR 303
+TEST(listener_test, listener_uses_default) {
+    uint16_t port_nb;
+
+    // This is just done to get the value of a free port. The socket will be closed
+    // after the closing curly bracket and the port will be free again (SO_REUSEADDR option).
+    // In theory, it is possible that some application grab this port before we bind it again...
+    {
+        SocketWrapper s = bind_free_port();
+        port_nb = s.port();
+    }
+
+
+    if (port_nb == 0) {
+        FAIL() << "Could not find a free port. Abord test.\n";
+    }
+
+    Pistache::Port port(port_nb);
+    Pistache::Address address(Pistache::Ipv4::any(), port);
+
+    Pistache::Tcp::Listener listener;
+    listener.setHandler(Pistache::Http::make_handler<DummyHandler>());
+    listener.bind(address);
+    ASSERT_TRUE(true);
+}
+
+
 
 TEST(listener_test, listener_bind_port_not_free_throw_runtime) {
 

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -109,7 +109,7 @@ TEST(listener_test, listener_bind_port_free) {
 
 
     if (port_nb == 0) {
-        FAIL() << "Could not find a free port. Abord test.\n";
+        FAIL() << "Could not find a free port. Abort test.\n";
     }
 
     Pistache::Port port(port_nb);
@@ -138,7 +138,7 @@ TEST(listener_test, listener_uses_default) {
 
 
     if (port_nb == 0) {
-        FAIL() << "Could not find a free port. Abord test.\n";
+        FAIL() << "Could not find a free port. Abort test.\n";
     }
 
     Pistache::Port port(port_nb);
@@ -158,7 +158,7 @@ TEST(listener_test, listener_bind_port_not_free_throw_runtime) {
     uint16_t port_nb = s.port();
 
     if (port_nb == 0) {
-        FAIL() << "Could not find a free port. Abord test.\n";
+        FAIL() << "Could not find a free port. Abort test.\n";
     }
 
     Pistache::Port port(port_nb);


### PR DESCRIPTION
2 changes here:
- The first one is to initialize explicitly the members of Listener. This is to fix the problem that happens when Listener::init is not called before running (see issue 302).
- Replace shared_ptr<Aio::Reactor> by a value owned by Listener. The pointer was never shared with anything else so it makes sense to use a value instead of a shared_ptr for this case.

Please do not merge yet -> Will add a UT where listener is not init, but does not crash.