### PR TITLE
Tiny change in thread management

### DIFF
--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -74,7 +74,7 @@ private:
     Polling::Epoll poller;
 
     Flags<Options> options_;
-    std::unique_ptr<std::thread> acceptThread;
+    std::thread acceptThread;
 
     size_t workers_;
     std::shared_ptr<Transport> transport_;

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -99,8 +99,10 @@ Listener::Listener(const Address& address)
 }
 
 Listener::~Listener() {
-    if (isBound()) shutdown();
-    if (acceptThread) acceptThread->join();
+    if (isBound())
+        shutdown();
+    if (acceptThread.joinable())
+        acceptThread.join();
 }
 
 void
@@ -243,7 +245,7 @@ Listener::run() {
 void
 Listener::runThreaded() {
     shutdownFd.bind(poller);
-    acceptThread.reset(new std::thread([=]() { this->run(); }));
+    acceptThread = std::thread([=]() { this->run(); });
 }
 
 void


### PR DESCRIPTION
In this PR I propose tiny changes in `Listener` implementation:
1. Before calling `join` for thead it would be better to check that it's joinable;
2. In my opinion using `std::unique_ptr` is redundant in this case.