### PR TITLE
Add address reuse in http client test

### DIFF
--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,6 +14,8 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
+    , flags_()
+    , backlog_(Const::MaxBacklog)
     , maxPayload_(Const::DefaultMaxPayload)
 { }
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,6 +14,7 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
+    , maxPayload_(Const::DefaultMaxPayload)
 { }
 
 Endpoint::Options&

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -1,8 +1,8 @@
-#include "gtest/gtest.h"
-
 #include <pistache/http.h>
 #include <pistache/client.h>
 #include <pistache/endpoint.h>
+
+#include "gtest/gtest.h"
 
 #include <chrono>
 
@@ -11,9 +11,8 @@ using namespace Pistache;
 struct HelloHandler : public Http::Handler {
     HTTP_PROTOTYPE(HelloHandler)
 
-    void onRequest(const Http::Request& request, Http::ResponseWriter writer)
+    void onRequest(const Http::Request& /*request*/, Http::ResponseWriter writer)
     {
-        UNUSED(request)
         writer.send(Http::Code::Ok, "Hello, World!");
     }
 };
@@ -22,7 +21,8 @@ TEST(request_builder, multiple_send_test) {
     const std::string address = "localhost:9080";
 
     Http::Endpoint server(address);
-    auto server_opts = Http::Endpoint::options().threads(1);
+    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
     server.serveThreaded();


### PR DESCRIPTION
This is the first part of changes for fixing http client test. We definitelly should create server with `Tcp::Options::ReuseAddr` option. Now I'm researching the roots of the following problem:
```
10: [ RUN      ] request_builder.multiple_send_test
10: terminate called after throwing an instance of 'Pistache::Http::HttpError'
10:   what():  Encountered invalid HTTP version
1/1 Test #10: http_client_test .................***Exception: Child aborted  0.50 sec
```
This problem was raised after my [commit](https://github.com/oktal/pistache/commit/11bba3e994d33f1e9b476b15a2f8f3e8c3d1bd65) when I added http client test for checking multiple send method calls.