### PR TITLE
Test fix: partially revert 4b18505 that breaks http_client_test + add more tests

### DIFF
--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -316,11 +316,12 @@ Transport::handleWriteQueue() {
 
         auto &write = entry->data();
         auto fd = write.peerFd;
+        toWrite[fd].push_back(std::move(write));
         // Sometimes writes can be enqueued after a client has already disconnected.
-        // In that case, clear the queue
-        auto it = toWrite.find(fd);
-        if (it == std::end(toWrite)) { continue; }
-        it->second.push_back(std::move(write));
+        // // In that case, clear the queue
+        // auto it = toWrite.find(fd);
+        // if (it == std::end(toWrite)) { continue; }
+        // it->second.push_back(std::move(write));
         reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
     }
 }

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -17,7 +17,41 @@ struct HelloHandler : public Http::Handler {
     }
 };
 
-TEST(request_builder, multiple_send_test) {
+TEST(http_client_test, one_client_with_one_request) {
+    const std::string address = "localhost:9079";
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+
+    Http::Client client;
+    auto client_opts = Http::Client::options();
+    client.init(client_opts);
+
+    std::vector<Async::Promise<Http::Response>> responses;
+    auto rb = client.get(address);
+    auto response = rb.send();
+    bool done = false;
+    response.then([&](Http::Response rsp) {
+        if (rsp.code() == Http::Code::Ok)
+            done = true;
+        }, Async::IgnoreException);
+    responses.push_back(std::move(response));
+
+    auto sync = Async::whenAll(responses.begin(), responses.end());
+    Async::Barrier<std::vector<Http::Response>> barrier(sync);
+    barrier.wait_for(std::chrono::seconds(5));
+
+    server.shutdown();
+    client.shutdown();
+
+    ASSERT_TRUE(done);
+}
+
+TEST(http_client_test, one_client_with_multiple_requests) {
     const std::string address = "localhost:9080";
 
     Http::Endpoint server(address);
@@ -54,4 +88,61 @@ TEST(request_builder, multiple_send_test) {
     client.shutdown();
 
     ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+}
+
+TEST(http_client_test, multiple_clients_with_one_request) {
+    const std::string address = "localhost:9081";
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+
+    auto client_opts = Http::Client::options();
+    const int CLIENT_SIZE = 3;
+    Http::Client client1;
+    client1.init(client_opts);
+    Http::Client client2;
+    client2.init(client_opts);
+    Http::Client client3;
+    client3.init(client_opts);
+
+    std::vector<Async::Promise<Http::Response>> responses;
+    int response_counter = 0;
+
+    auto rb1 = client1.get(address);
+    auto response1 = rb1.send();
+    response1.then([&](Http::Response rsp) {
+            if (rsp.code() == Http::Code::Ok)
+                ++response_counter;
+        }, Async::IgnoreException);
+    responses.push_back(std::move(response1));
+    auto rb2 = client2.get(address);
+    auto response2 = rb2.send();
+    response2.then([&](Http::Response rsp) {
+            if (rsp.code() == Http::Code::Ok)
+                ++response_counter;
+        }, Async::IgnoreException);
+    responses.push_back(std::move(response2));
+    auto rb3 = client3.get(address);
+    auto response3 = rb3.send();
+    response3.then([&](Http::Response rsp) {
+            if (rsp.code() == Http::Code::Ok)
+                ++response_counter;
+        }, Async::IgnoreException);
+    responses.push_back(std::move(response3));
+
+    auto sync = Async::whenAll(responses.begin(), responses.end());
+    Async::Barrier<std::vector<Http::Response>> barrier(sync);
+
+    barrier.wait_for(std::chrono::seconds(5));
+
+    server.shutdown();
+    client1.shutdown();
+    client2.shutdown();
+    client3.shutdown();
+
+    ASSERT_TRUE(response_counter == CLIENT_SIZE);
 }


### PR DESCRIPTION
In this PR I have partially reverted [4b18505](https://github.com/oktal/pistache/commit/4b185059fbae6c96f330dbf5550f38f38d82a861) that breaks `http_client_test` and added more tests. I will continue explore how Transport works and propose better solution but for this moment it's just partially revert to fix test.  