### PR TITLE
Improve Client and Endpoint init API and tiny changes in tests

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -306,7 +306,6 @@ public:
            : threads_(Default::Threads)
            , maxConnectionsPerHost_(Default::MaxConnectionsPerHost)
            , keepAlive_(Default::KeepAlive)
-
        { }
 
        Options& threads(int val);
@@ -323,7 +322,7 @@ public:
    ~Client();
 
    static Options options();
-   void init(const Options& options);
+   void init(const Options& options = Options());
 
    RequestBuilder get(const std::string& resource);
    RequestBuilder post(const std::string& resource);

--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -38,7 +38,7 @@ public:
         listener.init(std::forward<Args>(args)...);
     }
 
-    void init(const Options& options);
+    void init(const Options& options = Options());
     void setHandler(const std::shared_ptr<Handler>& handler);
 
     void bind();

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,7 +14,7 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
-    , flags_()
+    , flags_(Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr)
     , backlog_(Const::MaxBacklog)
     , maxPayload_(Const::DefaultMaxPayload)
 { }

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -21,15 +21,12 @@ TEST(http_client_test, one_client_with_one_request) {
     const std::string address = "localhost:9079";
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
-    server.init(server_opts);
+    server.init();
     server.setHandler(Http::make_handler<HelloHandler>());
     server.serveThreaded();
 
     Http::Client client;
-    auto client_opts = Http::Client::options();
-    client.init(client_opts);
+    client.init();
 
     std::vector<Async::Promise<Http::Response>> responses;
     auto rb = client.get(address);
@@ -55,15 +52,12 @@ TEST(http_client_test, one_client_with_multiple_requests) {
     const std::string address = "localhost:9080";
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
-    server.init(server_opts);
+    server.init();
     server.setHandler(Http::make_handler<HelloHandler>());
     server.serveThreaded();
 
     Http::Client client;
-    auto client_opts = Http::Client::options().threads(1).maxConnectionsPerHost(1);
-    client.init(client_opts);
+    client.init();
 
     std::vector<Async::Promise<Http::Response>> responses;
     const int RESPONSE_SIZE = 3;
@@ -94,20 +88,17 @@ TEST(http_client_test, multiple_clients_with_one_request) {
     const std::string address = "localhost:9081";
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-    auto server_opts = Http::Endpoint::options().flags(flags).threads(1);
-    server.init(server_opts);
+    server.init();
     server.setHandler(Http::make_handler<HelloHandler>());
     server.serveThreaded();
 
-    auto client_opts = Http::Client::options();
     const int CLIENT_SIZE = 3;
     Http::Client client1;
-    client1.init(client_opts);
+    client1.init();
     Http::Client client2;
-    client2.init(client_opts);
+    client2.init();
     Http::Client client3;
-    client3.init(client_opts);
+    client3.init();
 
     std::vector<Async::Promise<Http::Response>> responses;
     int response_counter = 0;

--- a/tests/payload_test.cc
+++ b/tests/payload_test.cc
@@ -88,11 +88,8 @@ TEST(payload, from_description)
 
         router.initFromDescription(desc);
 
-        auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-
         auto opts = Http::Endpoint::options()
             .threads(threads)
-            .flags(flags)
             .maxPayload(maxPayload);
             ;
 
@@ -142,7 +139,6 @@ TEST(payload, manual_construction) {
     Port    port(PORT);
     Address addr(Ipv4::any(), port);
     int     threads = 20;
-    auto    flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
     size_t  maxPayload = 2048;
 
     auto pid = fork();
@@ -150,7 +146,6 @@ TEST(payload, manual_construction) {
         auto endpoint = std::make_shared<Http::Endpoint>(addr);
         auto opts = Http::Endpoint::options()
             .threads(threads)
-            .flags(flags)
             .maxPayload(maxPayload);
             ;
 

--- a/tests/streaming_test.cc
+++ b/tests/streaming_test.cc
@@ -63,11 +63,8 @@ TEST(stream, from_description)
 
     router.initFromDescription(desc);
 
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-
     auto opts = Http::Endpoint::options()
         .threads(threads)
-        .flags(flags)
         .maxPayload(1024*1024)
         ;
 


### PR DESCRIPTION
In this PR I'm proposing tiny improvements in `init` method of `Client` and `Endpoint` classes. I have some doubts about setting `InstallSignalHandler` and `ReuseAddr` flags as defaults ones on server, but it looks reasonable:
1) It's ok by default to reuse address for listening;
2) It's ok to catch `SIGINT` by default.