### PR TITLE
Small fix for cookies with small Max Age

### DIFF
--- a/include/pistache/cookie.h
+++ b/include/pistache/cookie.h
@@ -103,7 +103,7 @@ public:
     CookieJar();
 
     void add(const Cookie& cookie);
-    void removeCookie(const std::string& name);  // Unimplemented
+    void removeAllCookies();  
     
     void addFromRaw(const char *str, size_t len);
     Cookie get(const std::string& name) const;

--- a/src/common/cookie.cc
+++ b/src/common/cookie.cc
@@ -224,9 +224,9 @@ CookieJar::add(const Cookie& cookie) {
 
 }
 
-void // Unimplemented
-CookieJar::removeCookie(const std::string& name) {
-	// Empty for now, can be used later
+void 
+CookieJar::removeAllCookies() {
+	cookies.clear();
 }
 
 void

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -294,6 +294,7 @@ namespace Private {
             }
 
             if (name == "Cookie") {
+                message->cookies_.removeAllCookies(); // removing existing cookies before re-adding them.
                 message->cookies_.addFromRaw(cursor.offset(start), cursor.diff(start));
             }
 


### PR DESCRIPTION
Whenever you make a request, cookies from the client/browser are re-added into cookieJar. This behaviour is good because cookies from the client/browser are relable. But in this scenario where;
- We create a cookie with small max age,
-immediately make a request -> this will lead to the small aged cookie to be added into CookieJar
- this jar stay in CookieJar forever, because nothing is removing it, while this small aged cookie is already removed from client/browser.

So in this solution;

- Whenever we make a request, i empty the cookieJar before adding cookies from client/browser. This way only the reliable cookies from client/browser are in the cookieJar.

You can edit the code as you see fit.