### PR TITLE
Relaxed CMAKE version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8.2)
+cmake_minimum_required (VERSION 3.1.3)
 project (pistache)
 
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-missing-field-initializers")
@@ -7,16 +7,27 @@ option(PISTACHE_BUILD_TESTS "build tests alongside the project" OFF)
 option(PISTACHE_BUILD_EXAMPLES "build examples alongside the project" OFF)
 option(PISTACHE_INSTALL "add pistache as install target (recommended)" ON)
 
-# Clang exports C++17 in std::experimental namespace (tested on Clang 5 and 6).
-# This gives an error on date.h external library.
-# Following workaround forces Clang to compile at best with C++14
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_STANDARD 14)
-else()
-    set(CMAKE_CXX_STANDARD 17)
+# CMAKE version less than 3.8 does not understand the CMAKE_CXX_FLAGS
+# set to 17, so a manual check if performed on older version
+if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+    if(COMPILER_SUPPORTS_CXX11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+    else()
+        set(CMAKE_CXX_STANDARD 14)
+    endif()
+    # Clang exports C++17 in std::experimental namespace (tested on Clang 5 and 6).
+    # This gives an error on date.h external library.
+    # Following workaround forces Clang to compile at best with C++14
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_STANDARD 14)
+    else()
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+    set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED OFF)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_subdirectory (src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,12 @@ option(PISTACHE_INSTALL "add pistache as install target (recommended)" ON)
 if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
-    if(COMPILER_SUPPORTS_CXX11)
+    if(COMPILER_SUPPORTS_CXX17)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
     else()
         set(CMAKE_CXX_STANDARD 14)
     endif()
+else()
     # Clang exports C++17 in std::experimental namespace (tested on Clang 5 and 6).
     # This gives an error on date.h external library.
     # Following workaround forces Clang to compile at best with C++14


### PR DESCRIPTION
Resolve the problem shown by @janhkrueger in #306 by lowering the CMAKE required version and using a manual check on C++17 support for versions lower than 3.8