### PR TITLE
Reduced compiler warnings in string_view

### DIFF
--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -65,7 +65,7 @@ namespace std {
         }
 
 
-        constexpr const char operator[](size_type pos) const {
+        constexpr char operator[](size_type pos) const {
             return data_[pos];
         }
 
@@ -109,7 +109,7 @@ namespace std {
                 pos = size_ - v.size_;
             }
 
-            for(; pos >= 0 && pos != npos; pos--) {
+            for(; pos != npos; pos--) {
                 string_view compare = substr(pos, v.size_);
                 if (v == compare) {
                     return pos;

--- a/tests/string_view_test.cc
+++ b/tests/string_view_test.cc
@@ -19,18 +19,18 @@ TEST(string_view_test, find_test) {
     std::string_view orig ("test");
     std::string_view find ("est");
 
-    ASSERT_EQ(orig.find(find), 1);
-    ASSERT_EQ(orig.find(find, 1), 1);
+    ASSERT_EQ(orig.find(find), std::size_t(1));
+    ASSERT_EQ(orig.find(find, 1), std::size_t(1));
     ASSERT_EQ(orig.find(find, 2), std::size_t(-1));
 
-    ASSERT_EQ(orig.find('e'), 1);
-    ASSERT_EQ(orig.find('e', 1), 1);
+    ASSERT_EQ(orig.find('e'), std::size_t(1));
+    ASSERT_EQ(orig.find('e', 1), std::size_t(1));
     ASSERT_EQ(orig.find('e', 2), std::size_t(-1));
     ASSERT_EQ(orig.find('1'), std::size_t(-1));
 
-    ASSERT_EQ(orig.find("est"), 1);
-    ASSERT_EQ(orig.find("est", 1), 1);
-    ASSERT_EQ(orig.find("est", 1, 2), 1);
+    ASSERT_EQ(orig.find("est"), std::size_t(1));
+    ASSERT_EQ(orig.find("est", 1), std::size_t(1));
+    ASSERT_EQ(orig.find("est", 1, 2), std::size_t(1));
     ASSERT_EQ(orig.find("set"), std::size_t(-1));
     ASSERT_EQ(orig.find("est", 2), std::size_t(-1));
     ASSERT_EQ(orig.find("est", 2, 2), std::size_t(-1));
@@ -40,16 +40,16 @@ TEST(string_view_test, rfind_test) {
     std::string_view orig ("test");
     std::string_view find ("est");
 
-    ASSERT_EQ(orig.rfind(find), 1);
-    ASSERT_EQ(orig.rfind(find, 1), 1);
+    ASSERT_EQ(orig.rfind(find), std::size_t(1));
+    ASSERT_EQ(orig.rfind(find, 1), std::size_t(1));
 
-    ASSERT_EQ(orig.rfind('e'), 1);
-    ASSERT_EQ(orig.rfind('e', 1), 1);
+    ASSERT_EQ(orig.rfind('e'), std::size_t(1));
+    ASSERT_EQ(orig.rfind('e', 1), std::size_t(1));
     ASSERT_EQ(orig.rfind('q'), std::size_t(-1));
 
-    ASSERT_EQ(orig.rfind("est"), 1);
-    ASSERT_EQ(orig.rfind("est", 1), 1);
-    ASSERT_EQ(orig.rfind("est", 1, 2), 1);
+    ASSERT_EQ(orig.rfind("est"), std::size_t(1));
+    ASSERT_EQ(orig.rfind("est", 1), std::size_t(1));
+    ASSERT_EQ(orig.rfind("est", 1, 2), std::size_t(1));
     ASSERT_EQ(orig.rfind("set"), std::size_t(-1));
 }
 


### PR DESCRIPTION
Cleaned up compiler warnings (comparison between signed and unsigned, ignored 'const'.