### PR TITLE
Fix two heap usage after free

### DIFF
--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -207,8 +207,8 @@ Transport::asyncWriteImpl(Fd fd)
             if (wq.size() == 0) {
                 toWrite.erase(fd);
                 reactor()->modifyFd(key(), fd, NotifyOn::Read, Polling::Mode::Edge);
+                stop = true;
             }
-            stop = true;
         };
 
         size_t totalWritten = buffer.offset();

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -191,7 +191,8 @@ Transport::asyncWriteImpl(Fd fd)
     // cleanup will have been handled by handlePeerDisconnection
     if (it == std::end(toWrite)) { return; }
     auto & wq = it->second;
-    while (wq.size() > 0) {
+    bool stop = false;
+    while (!stop && wq.size() > 0) {
         auto & entry = wq.front();
         int flags    = entry.flags;
         const BufferHolder &buffer = entry.buffer;
@@ -207,9 +208,9 @@ Transport::asyncWriteImpl(Fd fd)
                 toWrite.erase(fd);
                 reactor()->modifyFd(key(), fd, NotifyOn::Read, Polling::Mode::Edge);
             }
+            stop = true;
         };
 
-        bool halt = false;
         size_t totalWritten = buffer.offset();
         for (;;) {
             ssize_t bytesWritten = 0;
@@ -232,20 +233,19 @@ Transport::asyncWriteImpl(Fd fd)
                 else {
                     cleanUp();
                     deferred.reject(Pistache::Error::system("Could not write data"));
-                    halt = true;
                 }
                 break;
             }
             else {
                 totalWritten += bytesWritten;
                 if (totalWritten >= buffer.size()) {
-                    cleanUp();
-
                     if (buffer.isFile()) {
                         // done with the file buffer, nothing else knows whether to
                         // close it with the way the code is written.
                         ::close(buffer.fd());
                     }
+
+                    cleanUp();
 
                     // Cast to match the type of defered template
                     // to avoid a BadType exception
@@ -254,7 +254,6 @@ Transport::asyncWriteImpl(Fd fd)
                 }
             }
         }
-        if (halt) break;
     }
 }
 


### PR DESCRIPTION
In this PR I'm fixing two cases of heap usage after free:
1) We access `buffer` after deleting (in `cleanUp`) entry `wq.pop_front();` that contains it
2) We call `wq.size()` after deleting this queue (in `cleanUp`) using `toWrite.erase(fd);` call.
I will think about refactoring in this part of code.