### PR TITLE
Fix issue #346

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <algorithm>
 #include <memory>
+#include <string>
 
 #include <sys/timerfd.h>
 
@@ -443,7 +444,7 @@ class ResponseWriter : public Response {
 public:
     static constexpr size_t DefaultStreamSize = 512;
 
-    friend Async::Promise<ssize_t> serveFile(ResponseWriter&, const char *, const Mime::MediaType&);
+    friend Async::Promise<ssize_t> serveFile(ResponseWriter&, const std::string&, const Mime::MediaType&);
 
     friend class Handler;
     friend class Timeout;
@@ -602,7 +603,7 @@ private:
 };
 
 Async::Promise<ssize_t> serveFile(
-        ResponseWriter& response, const char *fileName,
+        ResponseWriter& response, const std::string& fileName,
         const Mime::MediaType& contentType = Mime::MediaType());
 
 namespace Private {

--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <limits>
 #include <iostream>
+#include <string>
 
 #include <pistache/os.h>
 
@@ -158,7 +159,6 @@ struct FileBuffer {
         , size_()
     { }
 
-    FileBuffer(const char* fileName);
     FileBuffer(const std::string& fileName);
 
     std::string fileName() const { return fileName_; }
@@ -166,7 +166,6 @@ struct FileBuffer {
     size_t size() const { return size_; }
 
 private:
-    void init(const char* fileName);
     std::string fileName_;
     Fd fd_;
     size_t size_;

--- a/src/common/description.cc
+++ b/src/common/description.cc
@@ -462,14 +462,14 @@ Swagger::install(Rest::Router& router) {
                 response.send(Http::Code::Moved_Permanently);
             } else {
                 auto index = uiDir.join("index.html");
-                Http::serveFile(response, index.c_str());
+                Http::serveFile(response, index);
             }
             return Route::Result::Ok;
         }
         else if (ui.isPrefix(req)) {
             auto file = ui.stripPrefix(req);
             auto path = uiDir.join(file);
-            Http::serveFile(response, path.c_str());
+            Http::serveFile(response, path);
             return Route::Result::Ok;
         }
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -681,11 +681,11 @@ ResponseWriter::putOnWire(const char* data, size_t len)
 }
 
 Async::Promise<ssize_t>
-serveFile(ResponseWriter& response, const char* fileName, const Mime::MediaType& contentType)
+serveFile(ResponseWriter& response, const std::string& fileName, const Mime::MediaType& contentType)
 {
     struct stat sb;
 
-    int fd = open(fileName, O_RDONLY);
+    int fd = open(fileName.c_str(), O_RDONLY);
     if (fd == -1) {
         std::string str_error(strerror(errno));
         if(errno == ENOENT) {
@@ -731,7 +731,7 @@ serveFile(ResponseWriter& response, const char* fileName, const Mime::MediaType&
     if (contentType.isValid()) {
         setContentType(contentType);
     } else {
-        auto mime = Mime::MediaType::fromFile(fileName);
+        auto mime = Mime::MediaType::fromFile(fileName.c_str());
         if (mime.isValid())
             setContentType(mime);
     }

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <string>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -15,25 +16,15 @@
 
 namespace Pistache {
 
-FileBuffer::FileBuffer(const char* fileName)
-    : fileName_(fileName)
-{
-    init(fileName);
-}
 
 FileBuffer::FileBuffer(const std::string& fileName)
     : fileName_(fileName)
 {
-    init(fileName.c_str());
-}
-
-void
-FileBuffer::init(const char* fileName)
-{
-    if (!fileName) {
-        throw std::runtime_error("Missing fileName");
+    if (fileName.empty()) {
+        throw std::runtime_error("Empty fileName");
     }
-    int fd = open(fileName, O_RDONLY);
+
+    int fd = open(fileName.c_str(), O_RDONLY);
     if (fd == -1) {
         throw std::runtime_error("Could not open file");
     }


### PR DESCRIPTION
In this PR I'm fixing issue #346 
File cannot be opened when we pass `const char *` of local `std::string` (using `c_str()` call) to `serveFile`. By the time of calling `FileBuffer::init` the local variable of type `std::string` is deleted and location of memory to `fileName` (that we got by `c_str()` call) contains garbage.