### PR TITLE
Make string_view find and rfind methods really noexcept

### DIFF
--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -11,7 +11,7 @@
 #           undef CUSTOM_STRING_VIEW
 #           include <experimental/string_view>
 			namespace std {
-				typedef experimental::string_view string_view;
+				using string_view = experimental::string_view;
 			}
 #       endif
 #   endif
@@ -25,7 +25,7 @@
 #include <stdexcept>
 #include <cstring>
 
-typedef std::size_t size_type;
+using size_type = std::size_t ;
 
 namespace std {
 

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -115,7 +115,7 @@ namespace std {
         size_type rfind(string_view v, size_type pos = npos) const noexcept {
             if (v.size_ <= size_) {
                 size_t start = size_ - v.size_;
-                if (pos != std::string::npos)
+                if (pos != npos)
                     start = pos;
                 for (size_t offset = 0; offset <= pos; ++offset, --start) {
                     bool found = true;
@@ -130,7 +130,7 @@ namespace std {
                     }
                 }
             }
-            return std::string::npos;
+            return npos;
         }
 
         size_type rfind(char c, size_type pos = npos) const noexcept {

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -113,25 +113,27 @@ namespace std {
         }
 
         size_type rfind(string_view v, size_type pos = npos) const noexcept {
-            if (v.size_ <= size_) {
-                if (pos > size_)
-                    pos = size_;
-                size_t start = size_ - v.size_;
-                if (pos != npos)
-                    start = pos;
-                for (size_t offset = 0; offset <= pos; ++offset, --start) {
-                    bool found = true;
-                    for (size_t j = 0; j < v.size_; ++j) {
-                        if (data_[start + j] != v.data_[j]) {
-                            found = false;
-                            break;
-                        }
-                    }
-                    if (found) {
-                        return start;
+            if (v.size_ > size_)
+                return npos;
+
+            if (pos > size_)
+                pos = size_;
+            size_t start = size_ - v.size_;
+            if (pos != npos)
+                start = pos;
+            for (size_t offset = 0; offset <= pos; ++offset, --start) {
+                bool found = true;
+                for (size_t j = 0; j < v.size_; ++j) {
+                    if (data_[start + j] != v.data_[j]) {
+                        found = false;
+                        break;
                     }
                 }
+                if (found) {
+                    return start;
+                }
             }
+
             return npos;
         }
 

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -83,10 +83,18 @@ namespace std {
         operator=(const string_view &view) noexcept = default;
 
         size_type find(string_view v, size_type pos = 0) const noexcept {
-            for(; size_ - pos >= v.size_; pos++) {
-                string_view compare = substr(pos, v.size_);
-                if (v == compare) {
-                    return pos;
+            if (v.size_ <= (size_ - pos)) {
+                for (; pos <= (size_ - v.size_); ++pos) {
+                    bool found = true;
+                    for (size_type i = 0; i < v.size_; ++i) {
+                        if (data_[pos + i] != v.data_[i]) {
+                            found = false;
+                            break;
+                        }
+                    }
+                    if (found) {
+                        return pos;
+                    }
                 }
             }
             return npos;
@@ -105,17 +113,24 @@ namespace std {
         }
 
         size_type rfind(string_view v, size_type pos = npos) const noexcept {
-            if (pos >= size_) {
-                pos = size_ - v.size_;
-            }
-
-            for(; pos != npos; pos--) {
-                string_view compare = substr(pos, v.size_);
-                if (v == compare) {
-                    return pos;
+            if (v.size_ <= size_) {
+                size_t start = size_ - v.size_;
+                if (pos != std::string::npos)
+                    start = pos;
+                for (size_t offset = 0; offset <= pos; ++offset, --start) {
+                    bool found = true;
+                    for (size_t j = 0; j < v.size_; ++j) {
+                        if (data_[start + j] != v.data_[j]) {
+                            found = false;
+                            break;
+                        }
+                    }
+                    if (found) {
+                        return start;
+                    }
                 }
             }
-            return npos;
+            return std::string::npos;
         }
 
         size_type rfind(char c, size_type pos = npos) const noexcept {

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -114,6 +114,8 @@ namespace std {
 
         size_type rfind(string_view v, size_type pos = npos) const noexcept {
             if (v.size_ <= size_) {
+                if (pos > size_)
+                    pos = size_;
                 size_t start = size_ - v.size_;
                 if (pos != npos)
                     start = pos;

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -83,20 +83,25 @@ namespace std {
         operator=(const string_view &view) noexcept = default;
 
         size_type find(string_view v, size_type pos = 0) const noexcept {
-            if (v.size_ <= (size_ - pos)) {
-                for (; pos <= (size_ - v.size_); ++pos) {
-                    bool found = true;
-                    for (size_type i = 0; i < v.size_; ++i) {
-                        if (data_[pos + i] != v.data_[i]) {
-                            found = false;
-                            break;
-                        }
-                    }
-                    if (found) {
-                        return pos;
+            if (size_ < pos)
+                return npos;
+
+            if ((size_ - pos) < v.size_)
+                return npos;
+
+            for (; pos <= (size_ - v.size_); ++pos) {
+                bool found = true;
+                for (size_type i = 0; i < v.size_; ++i) {
+                    if (data_[pos + i] != v.data_[i]) {
+                        found = false;
+                        break;
                     }
                 }
+                if (found) {
+                    return pos;
+                }
             }
+
             return npos;
         }
 

--- a/tests/string_view_test.cc
+++ b/tests/string_view_test.cc
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 #include <pistache/string_view.h>
 
-#include <limits>
 #include <string>
 
 TEST(string_view_test, substr_test) {

--- a/tests/string_view_test.cc
+++ b/tests/string_view_test.cc
@@ -53,6 +53,32 @@ TEST(string_view_test, rfind_test) {
     ASSERT_EQ(orig.rfind("set"), std::size_t(-1));
 }
 
+TEST(string_view_test, rfind_test_2) {
+    std::string_view orig1 ("e");
+    std::string_view find1 ("e");
+
+    ASSERT_EQ(orig1.rfind(find1), std::size_t(0));
+    ASSERT_EQ(orig1.rfind(find1, 1), std::size_t(0));
+
+    std::string_view orig2 ("e");
+    std::string_view find2 ("");
+
+    ASSERT_EQ(orig2.rfind(find2), std::size_t(1));
+    ASSERT_EQ(orig2.rfind(find2, 1), std::size_t(1));
+
+    std::string_view orig3 ("");
+    std::string_view find3 ("e");
+
+    ASSERT_EQ(orig3.rfind(find3), std::size_t(-1));
+    ASSERT_EQ(orig3.rfind(find3, 1), std::size_t(-1));
+
+    std::string_view orig4 ("");
+    std::string_view find4 ("");
+
+    ASSERT_EQ(orig4.rfind(find4), std::size_t(0));
+    ASSERT_EQ(orig4.rfind(find4, 1), std::size_t(0));
+}
+
 TEST(string_view_test, emptiness) {
     std::string_view e1;
     std::string_view e2 ("");

--- a/tests/string_view_test.cc
+++ b/tests/string_view_test.cc
@@ -77,6 +77,12 @@ TEST(string_view_test, rfind_test_2) {
 
     ASSERT_EQ(orig4.rfind(find4), std::size_t(0));
     ASSERT_EQ(orig4.rfind(find4, 1), std::size_t(0));
+
+    std::string_view orig5 ("a");
+    std::string_view find5 ("b");
+
+    ASSERT_EQ(orig5.rfind(find5), std::size_t(-1));
+    ASSERT_EQ(orig5.rfind(find5, 4), std::size_t(-1));
 }
 
 TEST(string_view_test, emptiness) {

--- a/tests/string_view_test.cc
+++ b/tests/string_view_test.cc
@@ -1,6 +1,9 @@
 #include "gtest/gtest.h"
 #include <pistache/string_view.h>
 
+#include <limits>
+#include <string>
+
 TEST(string_view_test, substr_test) {
     std::string_view orig ("test");
     std::string_view targ ("est");
@@ -34,6 +37,24 @@ TEST(string_view_test, find_test) {
     ASSERT_EQ(orig.find("set"), std::size_t(-1));
     ASSERT_EQ(orig.find("est", 2), std::size_t(-1));
     ASSERT_EQ(orig.find("est", 2, 2), std::size_t(-1));
+}
+
+TEST(string_view_test, find_test_2) {
+    std::string_view orig1 ("test");
+    std::string_view find1 ("est");
+    ASSERT_EQ(orig1.find(find1, std::size_t(-1)), std::size_t(-1));
+    ASSERT_EQ(orig1.find(find1, std::size_t(-1) - 2), std::size_t(-1));
+
+    std::string_view orig2 ("test");
+    std::string_view find2 ("");
+    ASSERT_EQ(orig2.find(find2, std::size_t(6)), std::size_t(-1));
+    ASSERT_EQ(orig2.find(find2, std::size_t(2)), std::size_t(2));
+    ASSERT_EQ(orig2.find(find2, std::size_t(-1)), std::size_t(-1));
+
+    std::string_view orig3 ("");
+    std::string_view find3 ("");
+    ASSERT_EQ(orig3.find(find3, std::size_t(0)), std::size_t(0));
+    ASSERT_EQ(orig3.find(find3, std::size_t(6)), std::size_t(-1));
 }
 
 TEST(string_view_test, rfind_test) {


### PR DESCRIPTION
In this PR I have made changes in `string_view` `find` and `rfind` methods to make them really `noexpect`. Now `substr` call can throw exception in the current version of this method.