### PR TITLE
Client code refactoring

### DIFF
--- a/tests/cookie_test_3.cc
+++ b/tests/cookie_test_3.cc
@@ -1,3 +1,4 @@
+#include <pistache/async.h>
 #include <pistache/client.h>
 #include <pistache/cookie.h>
 #include <pistache/endpoint.h>
@@ -7,6 +8,7 @@
 
 #include <chrono>
 #include <unordered_map>
+#include <string>
 
 using namespace Pistache;
 
@@ -90,7 +92,6 @@ TEST(http_client_test, one_client_with_one_request_with_several_cookies) {
     response.then([&](Http::Response rsp) {
             for (auto&& cookie: rsp.cookies()) {
                 cookiesStorages[cookie.name] = cookie.value;
-                std::cout << "get: " << cookie.name << "\n";
             }
         },
         Async::IgnoreException);


### PR DESCRIPTION
In this PR I have made the following things that make the code better (from my point of view):
1) Replace `Buffer` to `std::string`. I think it would be better to use STL containers in **this case** instead of implementing your own.
2) Replace `DynamicStreamBuf` to `std::stringstream` and checking this stream in one place;
3) Remove from client explicit `delete[]` call. In modern C++ it would be better to avoid using raw pointers, explicit `new `and `delete` calls.
3) Fix several warnings