### PR TITLE
Refactoring and code improvements in http headers

### DIFF
--- a/examples/custom_header.cc
+++ b/examples/custom_header.cc
@@ -68,5 +68,5 @@ private:
 };
 
 int main() {
-    Header::Registry::registerHeader<XProtocolVersion>();
+    Header::Registry::instance().registerHeader<XProtocolVersion>();
 }

--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -13,6 +13,7 @@
 #include <memory>
 
 #include <pistache/http_header.h>
+#include <pistache/type_checkers.h>
 
 namespace Pistache {
 namespace Http {
@@ -128,28 +129,40 @@ private:
     std::unordered_map<std::string, Raw> rawHeaders;
 };
 
-struct Registry {
+class Registry {
 
-    typedef std::function<std::unique_ptr<Header>()> RegistryFunc;
+public:
+    Registry(const Registry&) = delete;
+    Registry& operator=(const Registry&) = delete;
+    static Registry& instance();
 
-    template<typename H>
-    static
-    typename std::enable_if<
-                IsHeader<H>::value, void
-             >::type
-    registerHeader() {
+    using RegistryFunc = std::function<std::unique_ptr<Header>()>;
+
+    template<typename H, REQUIRES(IsHeader<H>::value)>
+    void registerHeader() {
         registerHeader(H::Name, []() -> std::unique_ptr<Header> {
             return std::unique_ptr<Header>(new H());
         });
 
     }
 
-    static void registerHeader(std::string name, RegistryFunc func);
+    void registerHeader(std::string name, RegistryFunc func);
 
-    static std::vector<std::string> headersList();
+    std::vector<std::string> headersList();
 
-    static std::unique_ptr<Header> makeHeader(const std::string& name);
-    static bool isRegistered(const std::string& name);
+    std::unique_ptr<Header> makeHeader(const std::string& name);
+    bool isRegistered(const std::string& name);
+
+    using RegistryStorageType = std::unordered_map<
+        std::string,
+        Registry::RegistryFunc,
+        LowercaseHash,
+        LowercaseEqual>;
+
+private:
+    Registry();
+    ~Registry();
+    RegistryStorageType registry;
 };
 
 template<typename H>
@@ -157,7 +170,7 @@ struct Registrar {
     static_assert(IsHeader<H>::value, "Registrar only works with header types");
 
     Registrar() {
-        Registry::registerHeader<H>();
+        Registry::instance().registerHeader<H>();
     }
 };
 

--- a/include/pistache/type_checkers.h
+++ b/include/pistache/type_checkers.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Pistache {
+
+#define REQUIRES(condition) typename std::enable_if<(condition), int>::type = 0
+
+}

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -300,8 +300,8 @@ namespace Private {
             else if (name == "Set-Cookie") {
                 message->cookies_.add(Cookie::fromRaw(cursor.offset(start), cursor.diff(start)));
             }
-            else if (Header::Registry::isRegistered(name)) {
-                std::shared_ptr<Header::Header> header = Header::Registry::makeHeader(name);
+            else if (Header::Registry::instance().isRegistered(name)) {
+                std::shared_ptr<Header::Header> header = Header::Registry::instance().makeHeader(name);
                 header->parseRaw(cursor.offset(start), cursor.diff(start));
                 message->headers_.add(header);
             }

--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -7,22 +7,12 @@
 #include <unordered_map>
 #include <iterator>
 #include <stdexcept>
-#include <iostream>
 
 #include <pistache/http_headers.h>
 
 namespace Pistache {
 namespace Http {
 namespace Header {
-
-namespace {
-    std::unordered_map<
-        std::string,
-        Registry::RegistryFunc,
-        LowercaseHash,
-        LowercaseEqual
-    > registry;
-}
 
 RegisterHeader(Accept);
 RegisterHeader(AccessControlAllowOrigin);
@@ -46,6 +36,18 @@ toLowercase(std::string str) {
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
     return str;
 }
+
+Registry& Registry::instance() {
+    static Registry instance;
+
+    return instance;
+}
+
+Registry::Registry()
+{}
+
+Registry::~Registry()
+{}
 
 void
 Registry::registerHeader(std::string name, Registry::RegistryFunc func)


### PR DESCRIPTION
I have made several code changes:
1) Now register is a singlton class
2) Start improving methods API, see `registerHeader` example
3) Tiny improvements
