### PR TITLE
Fix Connection problem in Client + code refactoring + one more test

### DIFF
--- a/include/pistache/async.h
+++ b/include/pistache/async.h
@@ -159,6 +159,10 @@ namespace Async {
             }
         };
 
+        struct EmptyCall {
+            void operator()(size_t) const { }
+        };
+
         struct Core;
 
         class Request {
@@ -923,6 +927,8 @@ namespace Async {
     static constexpr Private::IgnoreException IgnoreException{};
     static constexpr Private::NoExcept NoExcept{};
     static constexpr Private::Throw Throw{};
+
+    static constexpr Private::EmptyCall EmptyCall{};
 
     namespace details {
 

--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -107,9 +107,6 @@ struct Connection : public std::enable_shared_from_this<Connection> {
     std::string dump() const;
 
 private:
-    struct sockaddr_in saddr;
-
-
     void processRequestQueue();
 
     struct RequestEntry {
@@ -129,6 +126,7 @@ private:
         OnDone onDone;
     };
 
+    struct sockaddr_in saddr;
     std::unique_ptr<RequestEntry> requestEntry;
     std::atomic<uint32_t> state_;
     ConnectionState connectionState_;

--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -41,8 +41,7 @@ struct Connection : public std::enable_shared_from_this<Connection> {
 
     Connection()
         : fd(-1)
-        , inflightCount(0)
-        , responsesReceived(0)
+        , requestEntry(nullptr)
         , connectionState_(NotConnected)
     {
         state_.store(static_cast<uint32_t>(State::Idle));
@@ -108,8 +107,6 @@ struct Connection : public std::enable_shared_from_this<Connection> {
     std::string dump() const;
 
 private:
-    std::atomic<int> inflightCount;
-    std::atomic<int> responsesReceived;
     struct sockaddr_in saddr;
 
 
@@ -132,15 +129,13 @@ private:
         OnDone onDone;
     };
 
+    std::unique_ptr<RequestEntry> requestEntry;
     std::atomic<uint32_t> state_;
     ConnectionState connectionState_;
     std::shared_ptr<Transport> transport_;
     Queue<RequestData> requestsQueue;
 
-    std::deque<RequestEntry> inflightRequests;
-
     TimerPool timerPool_;
-    Private::Parser<Http::Response> parser_;
 };
 
 class ConnectionPool {

--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -18,7 +18,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
In this PR I'm fixing the problem in `Connection` class. It can happen that (not so often, but tests show some flaky situations):
```
...
    transport_->asyncSendRequest(shared_from_this(), timer, std::move(buffer)).then(
        [=](ssize_t) mutable {
            inflightRequests.push_back(RequestEntry(std::move(resolveMover), std::move(rejectMover), std::move(timer), std::move(onDone)));
        },
...
```
is executed **after**:
```
...
void
Connection::handleResponsePacket(const char* buffer, size_t totalBytes) {
    parser_.feed(buffer, totalBytes);
    if (parser_.parse() == Private::State::Done) {
        if (!inflightRequests.empty()) {
...
```
and as a result we **miss response** to client because `inflightRequests` is empty. I have analyzed Client logic and understood that inflightRequests size **can not be more than one**. Am I right? I cannot reproduce the situation in which the size will be more than 2. When we pick connection and set it to`﻿Used` state we cannot put more requests, only after `handleResponsePacket` call we set it in `Idle` state . All in all, I have decided to remove `inflightRequests` from connection and use `std::unique_ptr<RequestEntry> requestEntry;` instead. In my case we set `requestEntry` before `asyncSendRequest` call and ﻿garantees everything will ok in `handleResponsePacket` call.