### PR TITLE
Remove EmptyCall

### DIFF
--- a/include/pistache/async.h
+++ b/include/pistache/async.h
@@ -159,10 +159,6 @@ namespace Async {
             }
         };
 
-        struct EmptyCall {
-            void operator()(size_t) const { }
-        };
-
         struct Core;
 
         class Request {
@@ -927,8 +923,6 @@ namespace Async {
     static constexpr Private::IgnoreException IgnoreException{};
     static constexpr Private::NoExcept NoExcept{};
     static constexpr Private::Throw Throw{};
-
-    static constexpr Private::EmptyCall EmptyCall{};
 
     namespace details {
 

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -512,7 +512,7 @@ Connection::performImpl(
 
     requestEntry.reset(new RequestEntry(std::move(resolve), std::move(reject), timer, std::move(onDone)));
     transport_->asyncSendRequest(shared_from_this(), timer, std::move(buffer)).then(
-        Async::EmptyCall,
+        [](size_t /*bytes*/) {},
         [&](std::exception_ptr e) { rejectClone(e); });
 }
 


### PR DESCRIPTION
In the previous PR I have made the `EmptyCall` functor very specific (`operator()(size_t)`) and in my opinion I was wrong. Let's revert this change.