### PR TITLE
Fix connection OnDone execution: problem was introduced in PR #374 + test

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -133,6 +133,7 @@ private:
     Queue<RequestData> requestsQueue;
 
     TimerPool timerPool_;
+    Private::Parser<Http::Response> parser;
 };
 
 class ConnectionPool {

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -415,7 +415,6 @@ Connection::hasTransport() const {
 void
 Connection::handleResponsePacket(const char* buffer, size_t totalBytes) {
 
-    Private::Parser<Http::Response> parser;
     parser.feed(buffer, totalBytes);
     if (parser.parse() == Private::State::Done) {
         if (requestEntry) {
@@ -425,6 +424,8 @@ Connection::handleResponsePacket(const char* buffer, size_t totalBytes) {
             }
 
             requestEntry->resolve(std::move(parser.response));
+            parser.reset();
+
             auto onDone = requestEntry->onDone;
 
             requestEntry.reset(nullptr);
@@ -432,9 +433,6 @@ Connection::handleResponsePacket(const char* buffer, size_t totalBytes) {
             if (onDone)
                 onDone();
         }
-    } else {
-        // TODO: Do more specific error
-        requestEntry->reject(Error("Response problem"));
     }
 }
 

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -208,7 +208,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_
 
     std::vector<Async::Promise<Http::Response>> responses;
     const int RESPONSE_SIZE = 6;
-    std::atomic<int> response_counter = 0;
+    std::atomic<int> response_counter(0);
 
     auto rb = client.get(address);
     for (int i = 0; i < RESPONSE_SIZE; ++i)

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -190,3 +190,46 @@ TEST(http_client_test, timeout_reject)
 
     ASSERT_TRUE(is_reject);
 }
+
+TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_host)
+{
+    const std::string address = "localhost:9104";
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+
+    Http::Client client;
+    auto opts = Http::Client::options().maxConnectionsPerHost(1).threads(2);
+    client.init(opts);
+
+    std::vector<Async::Promise<Http::Response>> responses;
+    const int RESPONSE_SIZE = 6;
+    std::atomic<int> response_counter = 0;
+
+    auto rb = client.get(address);
+    for (int i = 0; i < RESPONSE_SIZE; ++i)
+    {
+        auto response = rb.send();
+        response.then([&](Http::Response rsp)
+                      {
+                          if (rsp.code() == Http::Code::Ok)
+                              ++response_counter;
+                      },
+                      Async::IgnoreException);
+        responses.push_back(std::move(response));
+    }
+
+    auto sync = Async::whenAll(responses.begin(), responses.end());
+    Async::Barrier<std::vector<Http::Response>> barrier(sync);
+
+    barrier.wait_for(std::chrono::seconds(5));
+
+    server.shutdown();
+    client.shutdown();
+
+    ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+}


### PR DESCRIPTION
In this PR I'm fixing the problem with Connection that I have introduced in PR #374: when `maxConnectionsPerHost` is less than the number of requests for client.
The order of releasing `requestEntry` and calling `onDone` matter. I have added a test for reproducing this case. Also I have returned `Http::Response` parser to `Connection` level.