### PR TITLE
Ephemeral ports

### DIFF
--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -53,6 +53,10 @@ public:
         return listener.isBound();
     }
 
+    Port getPort() const {
+        return listener.getPort();
+    }
+
     Async::Promise<Tcp::Listener::Load> requestLoad(const Tcp::Listener::Load& old);
 
     static Options options();

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -53,6 +53,7 @@ public:
     void bind(const Address& address);
 
     bool isBound() const;
+    Port getPort() const;
 
     void run();
     void runThreaded();

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -179,3 +179,16 @@ TEST(listener_test, listener_bind_port_not_free_throw_runtime) {
         FAIL() << "Expected std::runtime_error";
     }
 }
+
+// Listener should be able to bind port 0 directly to get an ephemeral port.
+TEST(listener_test, listener_bind_ephemeral_port) {
+    Pistache::Port port(0);
+    Pistache::Address address(Pistache::Ipv4::any(), port);
+
+    Pistache::Tcp::Listener listener;
+    listener.setHandler(Pistache::Http::make_handler<DummyHandler>());
+    listener.bind(address);
+
+    Pistache::Port bound_port = listener.getPort();
+    ASSERT_TRUE(bound_port > (uint16_t)0);
+}


### PR DESCRIPTION
Adds ability to use an ephemeral TCP port for pistache.  Just specify "Port(0)" when creating an Endpoint.  The socket is created inside Listener::run() (like normal).  However, after the socket is created, you can obtain the actual port by calling Endpoint::getPort().

Caveat: Listener::run() creates the socket AND runs the event loop until Endpoint::shutdown() is called.  Endpoint::serve() directly calls Listener::run(), so your calling thread cannot get the port (since its all the same thread).  If your application runs the endpoint if a different thread (due to calling Endpoint::serveThreaded()), and port is not available until AFTER the socket is created, you will need to poll or have some other way to know when the socket is created.

IMHO, "Endpoint::serveThreaded()" should not return until the endpoint is fully initialized and ready to go, OR there should be another method in Endpoint that blocks until the worker thread and socket are ready.  I might add that in a future PR.