### PR TITLE
Improve use of enumeration sets (flags)

### DIFF
--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -45,7 +45,7 @@ public:
     explicit Listener(const Address& address);
     void init(
             size_t workers,
-            Flags<Options> options = Options::None,
+            Flags<Options> options = {},
             int backlog = Const::MaxBacklog);
     void setHandler(const std::shared_ptr<Handler>& handler);
 
@@ -62,7 +62,7 @@ public:
 
     Async::Promise<Load> requestLoad(const Load& old);
 
-    Options options() const;
+    Flags<Options> options() const;
     Address address() const;
 
     void pinWorker(size_t worker, const CpuSet& set);

--- a/include/pistache/os.h
+++ b/include/pistache/os.h
@@ -57,15 +57,11 @@ enum class Mode {
 };
 
 enum class NotifyOn {
-    None = 0,
-
-    Read     = 1,
-    Write    = Read << 1,
-    Hangup   = Read << 2,
-    Shutdown = Read << 3
+    Read,
+    Write,
+    Hangup,
+    Shutdown
 };
-
-DECLARE_FLAGS_OPERATORS(NotifyOn)
 
 struct Tag {
     friend class Epoll;
@@ -76,15 +72,13 @@ struct Tag {
 
     constexpr uint64_t value() const { return value_; }
 
-    friend constexpr bool operator==(Tag lhs, Tag rhs);
+    constexpr bool operator==( const Tag& other ) const {
+        return value_ == other.value_;
+    }
 
 private:
     uint64_t value_;
 };
-
-inline constexpr bool operator==(Tag lhs, Tag rhs) {
-    return lhs.value_ == rhs.value_;
-}
 
 struct Event {
     explicit Event(Tag _tag)

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -43,13 +43,13 @@ public:
         { }
 
         bool isReadable() const {
-            return flags.hasFlag(Polling::NotifyOn::Read);
+            return flags[Polling::NotifyOn::Read];
         }
         bool isWritable() const {
-            return flags.hasFlag(Polling::NotifyOn::Write);
+            return flags[Polling::NotifyOn::Write];
         }
         bool isHangup() const {
-            return flags.hasFlag(Polling::NotifyOn::Hangup);
+            return flags[Polling::NotifyOn::Hangup];
         }
 
         Fd getFd() const { return this->fd; }
@@ -131,25 +131,25 @@ public:
     std::vector<std::shared_ptr<Handler>> handlers(const Key& key);
 
     void registerFd(
-            const Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level);
     void registerFdOneShot(
-            const Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level);
 
     void registerFd(
-            const Key& key, Fd fd, Polling::NotifyOn interest,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
             Polling::Mode mode = Polling::Mode::Level);
     void registerFdOneShot(
-            const Key& key, Fd fd, Polling::NotifyOn interest,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
             Polling::Mode mode = Polling::Mode::Level);
 
     void modifyFd(
-            const Key& key, Fd fd, Polling::NotifyOn interest,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
             Polling::Mode mode = Polling::Mode::Level);
 
     void modifyFd(
-            const Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+            const Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level);
 
     void runOnce();

--- a/include/pistache/tcp.h
+++ b/include/pistache/tcp.h
@@ -19,18 +19,15 @@ namespace Tcp {
 class Peer;
 class Transport;
 
-enum class Options : uint64_t {
-    None                 = 0,
-    NoDelay              = 1,
-    Linger               = NoDelay << 1,
-    FastOpen             = Linger << 1,
-    QuickAck             = FastOpen << 1,
-    ReuseAddr            = QuickAck << 1,
-    ReverseLookup        = ReuseAddr << 1,
-    InstallSignalHandler = ReverseLookup << 1
+enum class Options {
+    NoDelay,
+    Linger,
+    FastOpen,
+    QuickAck,
+    ReuseAddr,
+    ReverseLookup,
+    InstallSignalHandler
 };
-
-DECLARE_FLAGS_OPERATORS(Options)
 
 class Handler : private Prototype<Handler> {
 public:

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -272,7 +272,8 @@ Transport::handleConnectionQueue() {
         int res = ::connect(conn->fd, data.addr, data.addr_len);
         if (res == -1) {
             if (errno == EINPROGRESS) {
-                reactor()->registerFdOneShot(key(), conn->fd, NotifyOn::Write | NotifyOn::Hangup | NotifyOn::Shutdown);
+                reactor()->registerFdOneShot(key(), conn->fd,
+                    make_flags({NotifyOn::Write, NotifyOn::Hangup, NotifyOn::Shutdown}));
             }
             else {
                 data.reject(Error::system("Failed to connect"));

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -207,13 +207,13 @@ namespace Polling {
     Epoll::toEpollEvents(const Flags<NotifyOn>& interest) {
         int events = 0;
 
-        if (interest.hasFlag(NotifyOn::Read))
+        if (interest[NotifyOn::Read])
             events |= EPOLLIN;
-        if (interest.hasFlag(NotifyOn::Write))
+        if (interest[NotifyOn::Write])
             events |= EPOLLOUT;
-        if (interest.hasFlag(NotifyOn::Hangup))
+        if (interest[NotifyOn::Hangup])
             events |= EPOLLHUP;
-        if (interest.hasFlag(NotifyOn::Shutdown))
+        if (interest[NotifyOn::Shutdown])
             events |= EPOLLRDHUP;
 
         return events;
@@ -224,13 +224,13 @@ namespace Polling {
         Flags<NotifyOn> flags;
 
         if (events & EPOLLIN)
-            flags.setFlag(NotifyOn::Read);
+            flags.set(NotifyOn::Read);
         if (events & EPOLLOUT)
-            flags.setFlag(NotifyOn::Write);
+            flags.set(NotifyOn::Write);
         if (events & EPOLLHUP)
-            flags.setFlag(NotifyOn::Hangup);
+            flags.set(NotifyOn::Hangup);
         if (events & EPOLLRDHUP) {
-            flags.setFlag(NotifyOn::Shutdown);
+            flags.set(NotifyOn::Shutdown);
         }
 
         return flags;

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -33,21 +33,21 @@ public:
     virtual void registerFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) = 0;
 
     virtual void registerFdOneShot(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) = 0;
 
     virtual void modifyFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) = 0;
 
@@ -101,7 +101,7 @@ public:
     void registerFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
 
@@ -112,7 +112,7 @@ public:
     void registerFdOneShot(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
 
@@ -123,7 +123,7 @@ public:
     void modifyFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
 
@@ -389,7 +389,7 @@ public:
     void registerFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
         dispatchCall(key, &SyncImpl::registerFd, fd, interest, tag, mode);
@@ -398,7 +398,7 @@ public:
     void registerFdOneShot(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
         dispatchCall(key, &SyncImpl::registerFdOneShot, fd, interest, tag, mode);
@@ -407,7 +407,7 @@ public:
     void modifyFd(
             const Reactor::Key& key,
             Fd fd,
-            Polling::NotifyOn interest,
+            Flags<Polling::NotifyOn> interest,
             Polling::Tag tag,
             Polling::Mode mode = Polling::Mode::Level) override {
         dispatchCall(key, &SyncImpl::modifyFd, fd, interest, tag, mode);
@@ -523,7 +523,7 @@ Reactor::handlers(const Reactor::Key& key) {
 
 void
 Reactor::registerFd(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
         Polling::Mode mode)
 {
     impl()->registerFd(key, fd, interest, tag, mode);
@@ -531,7 +531,7 @@ Reactor::registerFd(
 
 void
 Reactor::registerFdOneShot(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
         Polling::Mode mode)
 {
     impl()->registerFdOneShot(key, fd, interest, tag, mode);
@@ -539,7 +539,7 @@ Reactor::registerFdOneShot(
 
 void
 Reactor::registerFd(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
         Polling::Mode mode)
 {
     impl()->registerFd(key, fd, interest, Polling::Tag(fd), mode);
@@ -547,7 +547,7 @@ Reactor::registerFd(
 
 void
 Reactor::registerFdOneShot(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
         Polling::Mode mode)
 {
     impl()->registerFdOneShot(key, fd, interest, Polling::Tag(fd), mode);
@@ -555,7 +555,7 @@ Reactor::registerFdOneShot(
 
 void
 Reactor::modifyFd(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest, Polling::Tag tag,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest, Polling::Tag tag,
         Polling::Mode mode)
 {
     impl()->modifyFd(key, fd, interest, tag, mode);
@@ -563,7 +563,7 @@ Reactor::modifyFd(
 
 void
 Reactor::modifyFd(
-        const Reactor::Key& key, Fd fd, Polling::NotifyOn interest,
+        const Reactor::Key& key, Fd fd, Flags<Polling::NotifyOn> interest,
         Polling::Mode mode)
 {
     impl()->modifyFd(key, fd, interest, Polling::Tag(fd), mode);

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -238,7 +238,9 @@ Transport::asyncWriteImpl(Fd fd)
                 if (errno == EAGAIN || errno == EWOULDBLOCK) {
                     wq.pop_front();
                     wq.push_front(WriteEntry(std::move(deferred), buffer.detach(totalWritten), flags));
-                    reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
+                    reactor()->modifyFd( key(), fd,
+                        make_flags({NotifyOn::Read, NotifyOn::Write}),
+                        Polling::Mode::Edge);
                 }
                 else {
                     cleanUp();
@@ -332,7 +334,7 @@ Transport::handleWriteQueue() {
             toWrite[fd].push_back(std::move(write));
         }
 
-        reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
+        reactor()->modifyFd(key(), fd, make_flags({NotifyOn::Read, NotifyOn::Write}), Polling::Mode::Edge);
     }
 }
 
@@ -366,7 +368,7 @@ Transport::handlePeer(const std::shared_ptr<Peer>& peer) {
     peer->associateTransport(this);
 
     handler_->onConnection(peer);
-    reactor()->registerFd(key(), fd, NotifyOn::Read | NotifyOn::Shutdown, Polling::Mode::Edge);
+    reactor()->registerFd(key(), fd, make_flags({NotifyOn::Read, NotifyOn::Shutdown}), Polling::Mode::Edge);
 }
 
 void

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -46,23 +46,23 @@ namespace {
 }
 
 void setSocketOptions(Fd fd, Flags<Options> options) {
-    if (options.hasFlag(Options::ReuseAddr)) {
+    if (options[Options::ReuseAddr]) {
         int one = 1;
         TRY(::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof (one)));
     }
 
-    if (options.hasFlag(Options::Linger)) {
+    if (options[Options::Linger]) {
         struct linger opt;
         opt.l_onoff = 1;
         opt.l_linger = 1;
         TRY(::setsockopt(fd, SOL_SOCKET, SO_LINGER, &opt, sizeof (opt)));
     }
 
-    if (options.hasFlag(Options::FastOpen)) {
+    if (options[Options::FastOpen]) {
         int hint = 5;
         TRY(::setsockopt(fd, SOL_TCP, TCP_FASTOPEN, &hint, sizeof (hint)));
     }
-    if (options.hasFlag(Options::NoDelay)) {
+    if (options[Options::NoDelay]) {
         int one = 1;
         TRY(::setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof (one)));
     }
@@ -113,7 +113,7 @@ Listener::init(
     options_ = options;
     backlog_ = backlog;
 
-    if (options_.hasFlag(Options::InstallSignalHandler)) {
+    if (options_[Options::InstallSignalHandler]) {
         if (signal(SIGINT, handle_sigint) == SIG_ERR) {
             throw std::runtime_error("Could not install signal handler");
         }
@@ -251,7 +251,7 @@ Listener::run() {
             if (event.tag == shutdownFd.tag())
                 return;
 
-            if (event.flags.hasFlag(Polling::NotifyOn::Read)) {
+            if (event.flags[Polling::NotifyOn::Read]) {
                 auto fd = event.tag.value();
                 if (static_cast<ssize_t>(fd) == listen_fd) {
                     try {
@@ -337,7 +337,7 @@ Listener::address() const {
     return addr_;
 }
 
-Options
+Flags<Options>
 Listener::options() const {
     return options_;
 }

--- a/tests/cookie_test_3.cc
+++ b/tests/cookie_test_3.cc
@@ -28,7 +28,7 @@ TEST(http_client_test, one_client_with_one_request_with_onecookie) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<CookieHandler>());
@@ -69,7 +69,7 @@ TEST(http_client_test, one_client_with_one_request_with_several_cookies) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<CookieHandler>());

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -35,7 +35,7 @@ TEST(http_client_test, one_client_with_one_request)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -69,7 +69,7 @@ TEST(http_client_test, one_client_with_multiple_requests) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -110,7 +110,7 @@ TEST(http_client_test, multiple_clients_with_one_request) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -170,7 +170,7 @@ TEST(http_client_test, timeout_reject)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<DelayHandler>());
@@ -208,7 +208,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -254,7 +254,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_two_connections_per
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());

--- a/tests/http_server_test.cc
+++ b/tests/http_server_test.cc
@@ -75,7 +75,7 @@ TEST(http_server_test, client_disconnection_on_timeout_from_single_threaded_serv
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     const int SIX_SECONDS_DELAY = 6;
@@ -97,7 +97,7 @@ TEST(http_server_test, client_multiple_requests_disconnection_on_timeout_from_si
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
 
@@ -120,7 +120,7 @@ TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags).threads(3);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
@@ -154,7 +154,7 @@ TEST(http_server_test, multiple_client_with_different_requests_to_multithreaded_
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = make_flags({Tcp::Options::InstallSignalHandler, Tcp::Options::ReuseAddr});
     auto server_opts = Http::Endpoint::options().flags(flags).threads(3);
     server.init(server_opts);
     const int SIX_SECONDS_DELAY = 6;

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -202,7 +202,6 @@ TEST(listener_test, listener_bind_ephemeral_v6_port) {
         Pistache::Port port(0);
         Pistache::Address address(Pistache::Ipv6::any(), port);
 
-        Pistache::Flags<Pistache::Tcp::Options> options;
         listener.setHandler(Pistache::Http::make_handler<DummyHandler>());
         listener.bind(address);
 


### PR DESCRIPTION
Removes the necessity of declaring enumerators with single
bit set values (e.g. 1<<X) and the requirement of a "None"
special value (there is no such a thing as TCP option None).

Instead, operations that depend on a set of these
enumerators take a Flags<Enum> argument, which is now
implemented using a std::bitset.

Future work may include specialization of Flags such as
NotifyOn, where the value and operations make use of the
underlying C macros instead of an intermediate
bitset representation.

Possible optimizations would consist in turning the constructors
and other simple operations constexpr, although this is restricted
to C++14 or later (no loops in C++11 constexpr functions).

Type trait Pistache::Underlying_Type removed since GCC 4.6 does
not support C++11 (4.8.1 or greater).