### PR TITLE
Properly shutdown non-threaded serve

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -234,6 +234,7 @@ Listener::getPort() const {
 
 void
 Listener::run() {
+    shutdownFd.bind(poller);
     reactor_.run();
 
     for (;;) {
@@ -269,7 +270,6 @@ Listener::run() {
 
 void
 Listener::runThreaded() {
-    shutdownFd.bind(poller);
     acceptThread = std::thread([=]() { this->run(); });
 }
 


### PR DESCRIPTION
I noticed that when I call `endpoint->shutdown()`, the running `endpoint->serve()` never returns. After inspecting the code I saw that this is already being handled properly for `endpoint->serveThreaded()`, but not for `endpoint->serve()`.

This PR moves the necessary code from the `serveThreaded()` method to the `serve()` method, so both methods can be shutdown properly.

This is working great in my very quick test, but if this line was never added to the `serve()` method on purpose I would like to know why, so I can think of another solution.