### PR TITLE
Buffer overflow bug

### DIFF
--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -231,7 +231,7 @@ Address::init(const std::string& addr) {
         try {
             in_addr addr;
             char buff[INET_ADDRSTRLEN+1];
-            memcpy(buff, host_.c_str(), INET6_ADDRSTRLEN);
+            memcpy(buff, host_.c_str(), INET_ADDRSTRLEN);
             inet_pton(AF_INET, buff, &(addr));
         } catch (std::runtime_error) {
             throw std::invalid_argument("Invalid IPv4 address");


### PR DESCRIPTION
Noticed a build warning while building the most recent `master` branch:
![image](https://user-images.githubusercontent.com/774118/50537165-6e779580-0b54-11e9-864c-474ca468c814.png)

Tried to get through the quickstart guide and the application kept getting the `buffer overflow error`.

Upon further look at the culprit, there seems to be a copy/paste caused bug.

This single change removes the warning at compile time and fixes the bug.