### PR TITLE
Fix client send request problem (caused by connect and pop from queue order)

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -90,6 +90,11 @@ struct Connection : public std::enable_shared_from_this<Connection> {
             std::chrono::milliseconds timeout,
             OnDone onDone);
 
+    Async::Promise<Response> asyncPerform(
+            const Http::Request& request,
+            std::chrono::milliseconds timeout,
+            OnDone onDone);
+
     void performImpl(
             const Http::Request& request,
             std::chrono::milliseconds timeout,


### PR DESCRIPTION
In this PR I'm fixing a problem that can happen when we establish connection (`transport_->asyncConnect(...)`), call `Connection::processRequestQueue`, but `requestsQueue.push(RequestData(...))` call takes place after that. As a result we can lose at least one request in client. To solve this problem I put reqeust to queue (in cases when we don't have connection) and only after that call `conn->connect(helpers::httpAddr(s.first));`.