### PR TITLE
Simple patch to bugs listed in #392

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -338,7 +338,7 @@ Connection::connect(const Address& addr)
     struct addrinfo hints;
     struct addrinfo *addrs;
     memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_family = addr.family();    /* Allow IPv4 */
+    hints.ai_family = addr.family();
     hints.ai_socktype = SOCK_STREAM; /* Stream socket */
     hints.ai_flags = 0;
     hints.ai_protocol = 0;

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -338,7 +338,7 @@ Connection::connect(const Address& addr)
     struct addrinfo hints;
     struct addrinfo *addrs;
     memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
+    hints.ai_family = addr.family();    /* Allow IPv4 */
     hints.ai_socktype = SOCK_STREAM; /* Stream socket */
     hints.ai_flags = 0;
     hints.ai_protocol = 0;


### PR DESCRIPTION
See issue #392.

Essentially if the address is specified as either an IPv4 or IPv6 address then it uses the appropriate address family, if however it is a hostname (rather than an IP address) then it assumes IPv4.

In my eyes this patch is not the ideal solution as it doesn't implement Happy Eyeballs correctly, however it does fix the library such that all tests operate as expected without breaching the expectations of any users of the client portion of the library.

As such I propose we roll this patch until we have time to properly re-work the client side to include native dual-stack support.