### PR TITLE
Fixes memory leak in Listenter::bind()

### DIFF
--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -26,6 +26,42 @@
 
 namespace Pistache {
 
+// Wrapper around 'getaddrinfo()' that handles cleanup on destruction.
+class AddrInfo {
+public:
+    // Disable copy and assign.
+    AddrInfo(const AddrInfo &) = delete;
+    AddrInfo& operator=(const AddrInfo &) = delete;
+
+    // Default construction: do nothing.
+    AddrInfo() : addrs(nullptr) {}
+
+    ~AddrInfo() {
+        if (addrs) {
+            ::freeaddrinfo(addrs);
+        }
+    }
+
+    // Call "::getaddrinfo()", but stash result locally.  Takes the same args
+    // as the first 3 args to "::getaddrinfo()" and returns the same result.
+    int invoke(const char *node, const char *service,
+               const struct addrinfo *hints) {
+        if (addrs) {
+            ::freeaddrinfo(addrs);
+            addrs = nullptr;
+        }
+
+        return ::getaddrinfo(node, service, hints, &addrs);
+    }
+
+    const struct addrinfo *get_info_ptr() const {
+        return addrs;
+    }
+
+private:
+    struct addrinfo *addrs;
+};
+
 class Port {
 public:
     Port(uint16_t port = 0);

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -189,13 +189,14 @@ Listener::bind(const Address& address) {
 
     const auto& host = addr_.host();
     const auto& port = addr_.port().toString();
-    struct addrinfo *addrs;
-    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
+    AddrInfo addr_info;
+
+    TRY(addr_info.invoke(host.c_str(), port.c_str(), &hints));
 
     int fd = -1;
 
-    addrinfo *addr;
-    for (addr = addrs; addr; addr = addr->ai_next) {
+    const addrinfo * addr = nullptr;
+    for (addr = addr_info.get_info_ptr(); addr; addr = addr->ai_next) {
         fd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (fd < 0) continue;
 


### PR DESCRIPTION
Listener::bind() calls "getaddrinfo()", which allocates memory on the heap.  Later, Listenter::bind() has an exit path that fails to call "freeaddrinfo()".  I solved this by wrapping the "addr info" in a class that frees the addrinfo on destruction and provides read-only access to the same during its lifetime.

Addresses one memory leak from issue #399.