### PR TITLE
Ipv6 support

### DIFF
--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -48,8 +48,6 @@ public:
             Flags<Options> options = Options::None,
             int backlog = Const::MaxBacklog);
     void setHandler(const std::shared_ptr<Handler>& handler);
-    
-    static bool systemSupportsIpv6();
 
     void bind();
     void bind(const Address& address);

--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -102,12 +102,15 @@ private:
 class Ipv6 {
 public:
     Ipv6(uint16_t a, uint16_t b, uint16_t c, uint16_t d, uint16_t e, uint16_t f, uint16_t g, uint16_t h);
-    
+
     static Ipv6 any();
     static Ipv6 loopback();
-    
+
     std::string toString() const;
     void toNetwork(in6_addr*) const;
+
+    // Returns 'true' if the kernel/libc support IPV6, false if not.
+    static bool supported();
 
 private:
     uint16_t a;

--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -26,6 +26,42 @@
 
 namespace Pistache {
 
+// Wrapper around 'getaddrinfo()' that handles cleanup on destruction.
+class AddrInfo {
+public:
+    // Disable copy and assign.
+    AddrInfo(const AddrInfo &) = delete;
+    AddrInfo& operator=(const AddrInfo &) = delete;
+
+    // Default construction: do nothing.
+    AddrInfo() : addrs(nullptr) {}
+
+    ~AddrInfo() {
+        if (addrs) {
+            ::freeaddrinfo(addrs);
+        }
+    }
+
+    // Call "::getaddrinfo()", but stash result locally.  Takes the same args
+    // as the first 3 args to "::getaddrinfo()" and returns the same result.
+    int invoke(const char *node, const char *service,
+               const struct addrinfo *hints) {
+        if (addrs) {
+            ::freeaddrinfo(addrs);
+            addrs = nullptr;
+        }
+
+        return ::getaddrinfo(node, service, hints, &addrs);
+    }
+
+    const struct addrinfo *get_info_ptr() const {
+        return addrs;
+    }
+
+private:
+    struct addrinfo *addrs;
+};
+
 class Port {
 public:
     Port(uint16_t port = 0);

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -9,6 +9,7 @@
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <ifaddrs.h>
 #include <iostream>
 
 #include <pistache/net.h>
@@ -128,6 +129,32 @@ void Ipv6::toNetwork(in6_addr *addr6) const {
     }
     // Copy the bytes into the in6_addr struct
     memcpy(addr6->s6_addr16, remap_ip6, 16);
+}
+
+bool Ipv6::supported() {
+    struct ifaddrs *ifaddr = nullptr;
+    struct ifaddrs *ifa = nullptr;
+    int family, n;
+    bool supportsIpv6 = false;
+
+    if (getifaddrs(&ifaddr) == -1) {
+        throw std::runtime_error("Call to getifaddrs() failed");
+    }
+
+    for (ifa = ifaddr, n = 0; ifa != nullptr; ifa = ifa->ifa_next, n++) {
+        if (ifa->ifa_addr == nullptr) {
+            continue;
+        }
+
+        family = ifa->ifa_addr->sa_family;
+        if (family == AF_INET6) {
+            supportsIpv6 = true;
+            continue;
+        }
+    }
+
+    freeifaddrs(ifaddr);
+    return supportsIpv6;
 }
 
 Address::Address()

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -15,7 +15,6 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
-#include <ifaddrs.h>
 #include <netdb.h>
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
@@ -145,29 +144,6 @@ Listener::pinWorker(size_t worker, const CpuSet& set)
     auto &wrk = ioGroup[worker];
     wrk->pin(set);
 #endif
-}
-
-bool
-Listener::systemSupportsIpv6(){
-    struct ifaddrs *ifaddr, *ifa;
-    int family, n;
-    bool supportsIpv6 = false;
-    if (getifaddrs(&ifaddr) == -1) {
-        throw std::runtime_error("Call to getifaddrs() failed");
-    }
-    
-    for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
-            if (ifa->ifa_addr == NULL)
-                continue;
-
-            family = ifa->ifa_addr->sa_family;
-            if (family == AF_INET6) {
-                supportsIpv6 = true;
-                continue;
-            }
-    }
-    freeifaddrs(ifaddr);
-    return supportsIpv6;
 }
 
 void

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -189,13 +189,14 @@ Listener::bind(const Address& address) {
 
     const auto& host = addr_.host();
     const auto& port = addr_.port().toString();
-    struct addrinfo *addrs;
-    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
+    AddrInfo addr_info;
+
+    TRY(addr_info.invoke(host.c_str(), port.c_str(), &hints));
 
     int fd = -1;
 
-    addrinfo *addr;
-    for (addr = addrs; addr; addr = addr->ai_next) {
+    const addrinfo * addr = nullptr;
+    for (addr = addr_info.get_info_ptr(); addr; addr = addr->ai_next) {
         fd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (fd < 0) continue;
 

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -198,7 +198,7 @@ TEST(listener_test, listener_bind_ephemeral_v4_port) {
 
 TEST(listener_test, listener_bind_ephemeral_v6_port) {
     Pistache::Tcp::Listener listener;
-    if (listener.systemSupportsIpv6()) {
+    if (Pistache::Ipv6::supported()) {
         Pistache::Port port(0);
         Pistache::Address address(Pistache::Ipv6::any(), port);
 


### PR DESCRIPTION
Minor code refactor, no logic changes.  Move static utility function for checking ipv6 support from server class (Listener) to common class (Net), to make it cleaner to use from client.