### PR TITLE
Ephemeral port unit tests

### DIFF
--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -39,7 +39,7 @@ TEST(net_test, address_creation)
 
     Address address3(Ipv4(127, 0, 0, 1), Port(8080));
     ASSERT_EQ(address3.host(), "127.0.0.1");
-    ASSERT_EQ(address3.port(), 8080);    
+    ASSERT_EQ(address3.port(), 8080);
 
     Address address4(Ipv4::any(), Port(8080));
     ASSERT_EQ(address4.host(), "0.0.0.0");
@@ -48,7 +48,7 @@ TEST(net_test, address_creation)
     Address address5("*:8080");
     ASSERT_EQ(address5.host(), "0.0.0.0");
     ASSERT_EQ(address5.port(), 8080);
-    
+
     Address address6("[::1]:8080");
     ASSERT_EQ(address6.host(), "::1");
     ASSERT_EQ(address6.port(), 8080);
@@ -60,7 +60,7 @@ TEST(net_test, address_creation)
 
     Address address8(Ipv6(0, 0, 0, 0, 0, 0, 0, 1), Port(8080));
     ASSERT_EQ(address8.host(), "::1");
-    ASSERT_EQ(address8.port(), 8080);    
+    ASSERT_EQ(address8.port(), 8080);
 
     Address address9(Ipv6::any(), Port(8080));
     ASSERT_EQ(address9.host(), "::");
@@ -69,18 +69,18 @@ TEST(net_test, address_creation)
     Address address10("[::]:8080");
     ASSERT_EQ(address10.host(), "::");
     ASSERT_EQ(address10.port(), 8080);
-    
+
     Address address11("[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]:8080");
     ASSERT_EQ(address11.host(), "2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455");
     ASSERT_EQ(address11.port(), 8080);
-    
+
     Address address12(Ipv4::loopback(), Port(8080));
     ASSERT_EQ(address12.host(), "127.0.0.1");
-    ASSERT_EQ(address12.port(), 8080); 
-    
+    ASSERT_EQ(address12.port(), 8080);
+
     Address address13(Ipv6::loopback(), Port(8080));
     ASSERT_EQ(address13.host(), "::1");
-    ASSERT_EQ(address13.port(), 8080); 
+    ASSERT_EQ(address13.port(), 8080);
 }
 
 TEST(net_test, invalid_address)
@@ -89,7 +89,7 @@ TEST(net_test, invalid_address)
     ASSERT_THROW(Address("127.0.0.1:9999999"), std::invalid_argument);
     ASSERT_THROW(Address("127.0.0.1:"), std::invalid_argument);
     ASSERT_THROW(Address("127.0.0.1:-10"), std::invalid_argument);
-    
+
     /* Due to an error in GLIBC these tests don't fail as expected, further research needed */
 //     ASSERT_THROW(Address("[GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG]:8080");, std::invalid_argument);
 //     ASSERT_THROW(Address("[::GGGG]:8080");, std::invalid_argument);

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -38,6 +38,10 @@ public:
         httpEndpoint->shutdown();
     }
 
+    Port getPort() const {
+        return httpEndpoint->getPort();
+    }
+
 private:
     void setupRoutes() {
         using namespace Rest;
@@ -56,20 +60,21 @@ private:
 };
 
 TEST(rest_server_test, basic_test) {
-    Port port(9090);
     int thr = 1;
 
-    Address addr(Ipv4::any(), port);
+    Address addr(Ipv4::any(), Port(0));
 
     StatsEndpoint stats(addr);
 
     stats.init(thr);
     stats.start();
+    Port port = stats.getPort();
 
     cout << "Cores = " << hardware_concurrency() << endl;
     cout << "Using " << thr << " threads" << endl;
+    cout << "Port = " << port << endl;
 
-    httplib::Client client("localhost", 9090);
+    httplib::Client client("localhost", port);
     auto res = client.Get("/read/function1");
     ASSERT_EQ(res->status, 200);
     ASSERT_EQ(res->body, "1");

--- a/tests/streaming_test.cc
+++ b/tests/streaming_test.cc
@@ -14,7 +14,6 @@ using namespace Pistache;
 static const size_t N_LETTERS = 26;
 static const size_t LETTER_REPEATS = 100000;
 static const size_t SET_REPEATS = 10;
-static const uint16_t PORT = 9082;
 
 void dumpData(const Rest::Request&req, Http::ResponseWriter response) {
     UNUSED(req);
@@ -49,7 +48,7 @@ void dumpData(const Rest::Request&req, Http::ResponseWriter response) {
 
 TEST(stream, from_description)
 {
-    Address addr(Ipv4::any(), PORT);
+    Address addr(Ipv4::any(), Port(0));
     const size_t threads = 20;
 
     std::shared_ptr<Http::Endpoint> endpoint;
@@ -63,8 +62,7 @@ TEST(stream, from_description)
 
     router.initFromDescription(desc);
 
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
-
+    auto flags = Tcp::Options::ReuseAddr;
     auto opts = Http::Endpoint::options()
         .threads(threads)
         .flags(flags)
@@ -86,7 +84,8 @@ TEST(stream, from_description)
         return size * nmemb;
     };
 
-    std::string url = "http://localhost:" + std::to_string(PORT) + "/";
+    const auto port = endpoint->getPort();
+    std::string url = "http://localhost:" + std::to_string(port) + "/";
     CURLcode res = CURLE_FAILED_INIT;
     CURL * curl = curl_easy_init();
     if (curl)


### PR DESCRIPTION
Converted final unit tests to use ephemeral ports.

Verified that no test binds TCP ports between 9080 and 9099 using "strace -ff -o tmp/x make test; egrep connect tmp/x.*"