### PR TITLE
Fix data races in Client desctruction

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -368,6 +368,7 @@ private:
 
    Lock queuesLock;
    std::unordered_map<std::string, MPMCQueue<std::shared_ptr<Connection::RequestData>, 2048>> requestsQueues;
+   bool stopProcessPequestsQueues;
 
    RequestBuilder prepareRequest(const std::string& resource, Http::Method method);
 

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -203,7 +203,7 @@ TEST(http_client_test, timeout_reject)
     ASSERT_TRUE(is_reject);
 }
 
-TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_host)
+TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_host_and_two_threads)
 {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
@@ -219,6 +219,52 @@ TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_
 
     Http::Client client;
     auto opts = Http::Client::options().maxConnectionsPerHost(1).threads(2);
+    client.init(opts);
+
+    std::vector<Async::Promise<Http::Response>> responses;
+    const int RESPONSE_SIZE = 6;
+    std::atomic<int> response_counter(0);
+
+    auto rb = client.get(server_address);
+    for (int i = 0; i < RESPONSE_SIZE; ++i)
+    {
+        auto response = rb.send();
+        response.then([&](Http::Response rsp)
+                      {
+                          if (rsp.code() == Http::Code::Ok)
+                              ++response_counter;
+                      },
+                      Async::IgnoreException);
+        responses.push_back(std::move(response));
+    }
+
+    auto sync = Async::whenAll(responses.begin(), responses.end());
+    Async::Barrier<std::vector<Http::Response>> barrier(sync);
+
+    barrier.wait_for(std::chrono::seconds(5));
+
+    server.shutdown();
+    client.shutdown();
+
+    ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+}
+
+TEST(http_client_test, one_client_with_multiple_requests_and_two_connections_per_host_and_one_thread)
+{
+    const Pistache::Address address("localhost", Pistache::Port(0));
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+
+    const std::string server_address = "localhost:" + server.getPort().toString();
+    std::cout << "Server address: " << server_address << "\n";
+
+    Http::Client client;
+    auto opts = Http::Client::options().maxConnectionsPerHost(2).threads(1);
     client.init(opts);
 
     std::vector<Async::Promise<Http::Response>> responses;


### PR DESCRIPTION
In this PR I'm fixing data races problem that can happen in `~Client` call (during Client destruction). Method `processRequestQueue` is called in async way so during `requestsQueues` `unordered_map` destruction in `~Client` it can be read in `processRequestQueue`. I have fixed this problem by introducing new flag `stopProcessPequestsQueues` that can prevent reading `requestsQueues` in `processRequestQueue` after `shutdown` call. Also I have added one more http client test (in the near future I will reduce code duplication in tests).