### PR TITLE
First step of fixing memory leaks in Client

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -196,7 +196,7 @@ public:
     void registerPoller(Polling::Epoll& poller) override;
 
     Async::Promise<void>
-    asyncConnect(const std::shared_ptr<Connection>& connection, const struct sockaddr* address, socklen_t addr_len);
+    asyncConnect(std::shared_ptr<Connection> connection, const struct sockaddr* address, socklen_t addr_len);
 
     Async::Promise<ssize_t> asyncSendRequest(
             const std::shared_ptr<Connection>& connection,
@@ -216,14 +216,14 @@ private:
                 std::shared_ptr<Connection> connection, const struct sockaddr* addr, socklen_t addr_len)
             : resolve(std::move(resolve))
             , reject(std::move(reject))
-            , connection(std::move(connection))
+            , connection(connection)
             , addr(addr)
             , addr_len(addr_len)
         { }
 
         Async::Resolver resolve;
         Async::Rejection reject;
-        std::shared_ptr<Connection> connection;
+        std::weak_ptr<Connection> connection;
         const struct sockaddr* addr;
         socklen_t addr_len;
     };
@@ -261,7 +261,7 @@ private:
 
     void handleRequestsQueue();
     void handleConnectionQueue();
-    void handleIncoming(const std::shared_ptr<Connection>& connection);
+    void handleIncoming(std::shared_ptr<Connection> connection);
     void handleResponsePacket(const std::shared_ptr<Connection>& connection, const char* buffer, size_t totalBytes);
     void handleTimeout(const std::shared_ptr<Connection>& connection);
 


### PR DESCRIPTION
This is the first step of fixing memory leaks in `Client`. I just started from `ConnectionEntry` struct. In my opinion it should be used `std::weak_ptr` to hold connection to break cyclic references.