### PR TITLE
Macro for simple HTTP headers

### DIFF
--- a/include/pistache/http_header.h
+++ b/include/pistache/http_header.h
@@ -552,6 +552,25 @@ private:
     std::string ua_;
 };
 
+#define CUSTOM_HEADER(header_name) \
+    class header_name : public Pistache::Http::Header::Header {     \
+    public:                                                         \
+		    NAME(#header_name)                                          \
+                                                                    \
+		    header_name() = default;                                    \
+		                                                                \
+		    explicit header_name(const char* value)                     \
+        : value_{value} {}                                          \
+		                                                                \
+        explicit header_name(const std::string& value)              \
+        : value_(value) {}		                                      \
+		                                                                \
+		    void write(std::ostream& os) const final { os << value_; }; \
+                                                                    \
+    private:                                                        \
+    		std::string value_;                                         \
+    };                                                              \
+
 class Raw {
 public:
     Raw();

--- a/include/pistache/http_header.h
+++ b/include/pistache/http_header.h
@@ -553,23 +553,29 @@ private:
 };
 
 #define CUSTOM_HEADER(header_name) \
-    class header_name : public Pistache::Http::Header::Header {     \
-    public:                                                         \
-		    NAME(#header_name)                                          \
-                                                                    \
-		    header_name() = default;                                    \
-		                                                                \
-		    explicit header_name(const char* value)                     \
-        : value_{value} {}                                          \
-		                                                                \
-        explicit header_name(const std::string& value)              \
-        : value_(value) {}		                                      \
-		                                                                \
-		    void write(std::ostream& os) const final { os << value_; }; \
-                                                                    \
-    private:                                                        \
-    		std::string value_;                                         \
-    };                                                              \
+    class header_name : public Pistache::Http::Header::Header { \
+    public:                                                     \
+        NAME(#header_name)                                      \
+                                                                \
+        header_name() = default;                                \
+                                                                \
+        explicit header_name(const char* value)                 \
+        : value_{value} {}                                      \
+                                                                \
+        explicit header_name(std::string value)                 \
+        : value_(std::move(value)) {}                           \
+                                                                \
+        void parseRaw(const char *str, size_t len) final        \
+        { value_ = { str, len };}                               \
+                                                                \
+        void write(std::ostream& os) const final                \
+        { os << value_; };                                      \
+                                                                \
+        std::string val() const { return value_; };             \
+                                                                \
+    private:                                                    \
+        std::string value_;                                     \
+    };                                                          \
 
 class Raw {
 public:

--- a/src/common/mime.cc
+++ b/src/common/mime.cc
@@ -1,7 +1,7 @@
 /* mime.cc
    Mathieu Stefani, 29 August 2015
 
-   Implementaton of MIME Type parsing
+   Implementation of MIME Type parsing
 */
 
 #include <cstring>

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -280,7 +280,7 @@ Pistache::Rest::SegmentTreeNode::findRoute(
     } else {  // current leaf requested, or empty final optional
         if (!optional_.empty()) {
             // in case of more than one optional at this point, as it is an
-            // ambuiguity, it is resolved by using the first optional
+            // ambiguity, it is resolved by using the first optional
             auto optional = optional_.begin();
             // std::string opt {optional->first.data(), optional->first.length()};
             return optional->second->findRoute(path, params, splats);

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -8,8 +8,6 @@
 
 using namespace Pistache::Http;
 
-CUSTOM_HEADER(TestHeader)
-
 TEST(headers_test, accept) {
     Header::Accept a1;
     a1.parse("audio/*; q=0.2");
@@ -250,19 +248,19 @@ TEST(headers_test, host) {
     host.parse("localhost:8080");
     ASSERT_EQ(host.host(), "localhost");
     ASSERT_EQ(host.port(), 8080);
-    
+
 /* Due to an error in GLIBC these tests don't fail as expected, further research needed */
 //     ASSERT_THROW( host.parse("256.256.256.256:8080");, std::invalid_argument);
 //     ASSERT_THROW( host.parse("1.0.0.256:8080");, std::invalid_argument);
-    
+
     host.parse("[::1]:8080");
     ASSERT_EQ(host.host(), "[::1]");
     ASSERT_EQ(host.port(), 8080);
-    
+
     host.parse("[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]:8080");
     ASSERT_EQ(host.host(), "[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]");
     ASSERT_EQ(host.port(), 8080);
-    
+
 /* Due to an error in GLIBC these tests don't fail as expected, further research needed */
 //     ASSERT_THROW( host.parse("[GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG]:8080");, std::invalid_argument);
 //     ASSERT_THROW( host.parse("[::GGGG]:8080");, std::invalid_argument);
@@ -323,13 +321,23 @@ TEST(headers_test, access_control_allow_methods_test)
     ASSERT_EQ(allowMethods.val(), "GET, POST, DELETE");
 }
 
+CUSTOM_HEADER(TestHeader)
+
+TEST(header_test, macro_for_custom_headers)
+{
+    TestHeader testHeader;
+    ASSERT_TRUE(TestHeader::Name == "TestHeader");
+
+    testHeader.parse("Header Content Test");
+    ASSERT_EQ(testHeader.val(), "Header Content Test");
+}
+
 TEST(headers_test, add_new_header_test)
 {
     const std::string headerName = "TestHeader";
 
     ASSERT_FALSE(Header::Registry::instance().isRegistered(headerName));
     Header::Registry::instance().registerHeader<TestHeader>();
-    ASSERT_TRUE(TestHeader::Name == "TestHeader");
     ASSERT_TRUE(Header::Registry::instance().isRegistered(headerName));
 
     const auto& headersList = Header::Registry::instance().headersList();

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -8,14 +8,7 @@
 
 using namespace Pistache::Http;
 
-class TestHeader : public Header::Header {
-public:
-    NAME("TestHeader");
-
-    void write(std::ostream& os) const override {
-        os << "TestHeader";
-    }
-};
+CUSTOM_HEADER(TestHeader)
 
 TEST(headers_test, accept) {
     Header::Accept a1;
@@ -336,6 +329,7 @@ TEST(headers_test, add_new_header_test)
 
     ASSERT_FALSE(Header::Registry::instance().isRegistered(headerName));
     Header::Registry::instance().registerHeader<TestHeader>();
+    ASSERT_TRUE(TestHeader::Name == "TestHeader");
     ASSERT_TRUE(Header::Registry::instance().isRegistered(headerName));
 
     const auto& headersList = Header::Registry::instance().headersList();


### PR DESCRIPTION
This PR creates a Macro `CUSTOM_HEADER` for very simple HTTP Headers.

This has the benefit of still preserving the type safety of the library design as well as providing a quick and easy way to add custom headers without the hassle of writing the whole class structure.

I thought this PR is appropriate since I have seen many of this simplifications across the library like the function `Pistache::Http::listenAndServe` which improves the empty editor to hello world time.

I would recommend to review each commit on its own since the small changes may pollute a bit the editor. If you think the small changes should not be there by any reason please let me know and I can take them out.
