### PR TITLE
Work around regex_replace issue in GCC<4.9

### DIFF
--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -99,7 +99,7 @@ SegmentTreeNode::getSegmentType(const std::string_view& fragment) {
 
 std::string SegmentTreeNode::sanitizeResource(const std::string& path) {
     const auto& dup = std::regex_replace(path,
-        SegmentTreeNode::multiple_slash, "/");
+        SegmentTreeNode::multiple_slash, std::string("/"));
     if (dup[dup.length() - 1] == '/') {
         return dup.substr(1, dup.length() - 2);
     }


### PR DESCRIPTION
GCC pre 4.9 has issue with template arg deduction which means old call passing char[2] to std::regex_replace as replacement string fails to build.