### PR TITLE
https://github.com/oktal/pistache/issues/399

### DIFF
--- a/examples/custom_header.cc
+++ b/examples/custom_header.cc
@@ -33,7 +33,7 @@ public:
         , min(minor)
     { }
 
-    void parse(const std::string& str) {
+    void parse(const std::string& str) override {
         auto p = str.find('.');
         std::string major, minor;
         if (p != std::string::npos) {

--- a/include/pistache/mailbox.h
+++ b/include/pistache/mailbox.h
@@ -227,14 +227,16 @@ public:
     }
 
     std::unique_ptr<T> popSafe() {
-        std::unique_ptr<Entry> entry(pop());
+        std::unique_ptr<T> object;
 
+        std::unique_ptr<Entry> entry(pop());
         if (entry)
         {
-            return std::unique_ptr<T>(new T(std::move(entry->data())));
+            object.reset(new T(std::move(entry->data())));
+            entry->data().~T();
         }
 
-        return std::unique_ptr<T>();
+        return object;
     }
 
 private:

--- a/include/pistache/mailbox.h
+++ b/include/pistache/mailbox.h
@@ -169,8 +169,6 @@ public:
             new (&storage) T(std::forward<U>(u));
         }
 
-        ~Entry() = default;
-
         const T& data() const {
             return *reinterpret_cast<const T*>(&storage);
         }
@@ -228,8 +226,15 @@ public:
         return head == tail;
     }
 
-    std::unique_ptr<Entry> popSafe() {
-        return std::unique_ptr<Entry>(pop());
+    std::unique_ptr<T> popSafe() {
+        std::unique_ptr<Entry> entry(pop());
+
+        if (entry)
+        {
+            return std::unique_ptr<T>(new T(std::move(entry->data())));
+        }
+
+        return std::unique_ptr<T>();
     }
 
 private:

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -20,9 +20,14 @@
 
 #include <openssl/ssl.h>
 
+
 #endif /* PISTACHE_USE_SSL */
 
+
+
+
 namespace Pistache {
+    namespace Http { namespace Private { class ParserBase; } }
 namespace Tcp {
 
 class Transport;
@@ -33,7 +38,8 @@ public:
 
     Peer();
     Peer(const Address& addr);
-
+    ~Peer() {}
+    
     Address address() const;
     std::string hostname() const;
 
@@ -43,22 +49,9 @@ public:
     void associateSSL(void *ssl);
     void *ssl(void) const;
 
-    void putData(std::string name, std::shared_ptr<void> data);
-
-    std::shared_ptr<void> getData(std::string name) const;
-    template<typename T>
-    std::shared_ptr<T> getData(std::string name) const {
-        return std::static_pointer_cast<T>(getData(std::move(name)));
-    }
-
-    std::shared_ptr<void> tryGetData(std::string name) const;
-    template<typename T>
-    std::shared_ptr<T> tryGetData(std::string name) const {
-        auto data = tryGetData(std::move(name));
-        if (data == nullptr) return nullptr;
-
-        return std::static_pointer_cast<T>(data);
-    }
+    void putData(std::string name, std::shared_ptr<Pistache::Http::Private::ParserBase> data);
+    std::shared_ptr<Pistache::Http::Private::ParserBase> getData(std::string name) const;
+    std::shared_ptr<Pistache::Http::Private::ParserBase> tryGetData(std::string name) const;
 
     Async::Promise<ssize_t> send(const Buffer& buffer, int flags = 0);
 
@@ -71,7 +64,7 @@ private:
     Fd fd_;
 
     std::string hostname_;
-    std::unordered_map<std::string, std::shared_ptr<void>> data_;
+    std::unordered_map<std::string, std::shared_ptr<Pistache::Http::Private::ParserBase>> data_;
 
     void *ssl_;
 };

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -26,12 +26,12 @@ using namespace std;
 namespace Pistache {
 namespace Http {
 
-template<typename H, typename Stream, typename... Args>
-typename std::enable_if<Header::IsHeader<H>::value, Stream&>::type
-writeHeader(Stream& stream, Args&& ...args) {
-    H header(std::forward<Args>(args)...);
-
-    stream << H::Name << ": ";
+    template<typename H, typename Stream, typename... Args>
+    typename std::enable_if<Header::IsHeader<H>::value, Stream&>::type
+    writeHeader(Stream& stream, Args&& ...args) {
+        H header(std::forward<Args>(args)...);
+        
+        stream << H::Name << ": ";
     header.write(stream);
 
     stream << crlf;
@@ -822,7 +822,7 @@ Timeout::onTimeout(uint64_t numWakeup) {
 
 Private::Parser<Http::Request>&
 Handler::getParser(const std::shared_ptr<Tcp::Peer>& peer) const {
-    return *peer->getData<Private::Parser<Http::Request>>(ParserData);
+    return static_cast<Private::Parser<Http::Request>&>(*peer->getData(ParserData));
 }
 
 

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -68,7 +68,7 @@ Peer::fd() const {
 }
 
 void
-Peer::putData(std::string name, std::shared_ptr<void> data) {
+Peer::putData(std::string name, std::shared_ptr<Pistache::Http::Private::ParserBase> data) {
     auto it = data_.find(name);
     if (it != std::end(data_)) {
         throw std::runtime_error("The data already exists");
@@ -77,7 +77,7 @@ Peer::putData(std::string name, std::shared_ptr<void> data) {
     data_.insert(std::make_pair(std::move(name), std::move(data)));
 }
 
-std::shared_ptr<void>
+std::shared_ptr<Pistache::Http::Private::ParserBase>
 Peer::getData(std::string name) const {
     auto data = tryGetData(std::move(name));
     if (data == nullptr) {
@@ -87,7 +87,7 @@ Peer::getData(std::string name) const {
     return data;
 }
 
-std::shared_ptr<void>
+std::shared_ptr<Pistache::Http::Private::ParserBase>
 Peer::tryGetData(std::string(name)) const {
     auto it = data_.find(name);
     if (it == std::end(data_)) return nullptr;

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -354,16 +354,15 @@ void
 Transport::handleWriteQueue() {
     // Let's drain the queue
     for (;;) {
-        auto entry = writesQueue.popSafe();
-        if (!entry) break;
+        auto write = writesQueue.popSafe();
+        if (!write) break;
 
-        auto &write = entry->data();
-        auto fd = write.peerFd;
+        auto fd = write->peerFd;
         if (!isPeerFd(fd)) continue;
 
         {
             Guard guard(toWriteLock);
-            toWrite[fd].push_back(std::move(write));
+            toWrite[fd].push_back(std::move(*write));
         }
 
         reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
@@ -373,22 +372,20 @@ Transport::handleWriteQueue() {
 void
 Transport::handleTimerQueue() {
     for (;;) {
-        auto entry = timersQueue.popSafe();
-        if (!entry) break;
+        auto timer = timersQueue.popSafe();
+        if (!timer) break;
 
-        auto &timer = entry->data();
-        armTimerMsImpl(std::move(timer));
+        armTimerMsImpl(std::move(*timer));
     }
 }
 
 void
 Transport::handlePeerQueue() {
     for (;;) {
-        auto entry = peersQueue.popSafe();
-        if (!entry) break;
+        auto data = peersQueue.popSafe();
+        if (!data) break;
 
-        const auto &data = entry->data();
-        handlePeer(data.peer);
+        handlePeer(data->peer);
     }
 }
 

--- a/tests/https_server_test.cc
+++ b/tests/https_server_test.cc
@@ -21,7 +21,7 @@ static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp)
 struct HelloHandler : public Http::Handler {
     HTTP_PROTOTYPE(HelloHandler)
 
-    void onRequest(const Http::Request&, Http::ResponseWriter writer) {
+    void onRequest(const Http::Request&, Http::ResponseWriter writer) override {
         writer.send(Http::Code::Ok, "Hello, World!");
     }
 };


### PR DESCRIPTION
Fixing leaks in: https://github.com/oktal/pistache/issues/399

Mainly 2 issues:

1. mailbox.h leaking shared_ptr

Queue::Entry does not have a destructor. Anything put in "storage" will not be destroyed.
Queue::Entry stores std_shared_ptr in 'storage', so, the ref count never goes down.

Due to this, items extracted via: "Queue::popSafe()" will leak.
Note: ~Queue actually cleans up storage via manual call to destructors.
```
    virtual ~Queue() {
        while (!empty()) {
            Entry* e = pop();
            e->data().~T();
            delete e;
        }
        delete tail;
    }
```


2. std_shared_ptr<void>
peer.h:
```
    std::unordered_map<std::string, std::shared_ptr<void>> data_;
```

Notice the "void". When that is hash table is destroyed, the shared_ptrs will not destroy objects.

putData does:
```
void
Handler::onConnection(const std::shared_ptr<Tcp::Peer>& peer) {
    peer->putData(ParserData, std::make_shared<Private::Parser<Http::Request>>());
}
```

If peer dies with data in the hashTable then that data is leaked.
I don't see any destructor in peer that would clean the hash table.

To test:
Apply fix: https://github.com/arthurafarias/pistache/commit/90b7e324a141ffb48617421a3e57e9e106a5186a

Disable SIGINT signal handler (we want to close valgrind with CTRL-C)

```
# valgrind --leak-check=full run_http_server
```

Do some requests (telnet to 9080 and close it without sending an HTTP request)
Close application.

```
==13834== 3,168 (672 direct, 2,496 indirect) bytes in 4 blocks are definitely lost in loss record 51 of 52
==13834==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13834==    by 0x2D0934: __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) (new_allocator.h:111)
==13834==    by 0x2CFC18: std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) (alloc_traits.h:436)
==13834==    by 0x2CF009: std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, (__gnu_cxx::_Lock_policy)2> >&) (allocated_ptr.h:104)
==13834==    by 0x2CE6E2: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, Pistache::Address>(std::_Sp_make_shared_tag, Pistache::Tcp::Peer*, std::allocator<Pistache::Tcp::Peer> const&, Pistache::Address&&) (shared_ptr_base.h:635)
==13834==    by 0x2CDBD9: std::__shared_ptr<Pistache::Tcp::Peer, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<Pistache::Tcp::Peer>, Pistache::Address>(std::_Sp_make_shared_tag, std::allocator<Pistache::Tcp::Peer> const&, Pistache::Address&&) (shared_ptr_base.h:1295)
==13834==    by 0x2CCAE0: std::shared_ptr<Pistache::Tcp::Peer>::shared_ptr<std::allocator<Pistache::Tcp::Peer>, Pistache::Address>(std::_Sp_make_shared_tag, std::allocator<Pistache::Tcp::Peer> const&, Pistache::Address&&) (shared_ptr.h:344)
==13834==    by 0x2CAC8A: std::shared_ptr<Pistache::Tcp::Peer> std::allocate_shared<Pistache::Tcp::Peer, std::allocator<Pistache::Tcp::Peer>, Pistache::Address>(std::allocator<Pistache::Tcp::Peer> const&, Pistache::Address&&) (shared_ptr.h:691)
==13834==    by 0x2C8F01: std::shared_ptr<Pistache::Tcp::Peer> std::make_shared<Pistache::Tcp::Peer, Pistache::Address>(Pistache::Address&&) (shared_ptr.h:707)
==13834==    by 0x2C54A4: Pistache::Tcp::Listener::handleNewConnection() (listener.cc:392)
==13834==    by 0x2C4976: Pistache::Tcp::Listener::run() (listener.cc:270)
==13834==    by 0x2C2FD7: void Pistache::Http::Endpoint::serveImpl<void (Pistache::Tcp::Listener::*)()>(void (Pistache::Tcp::Listener::*)()) (endpoint.h:141)
==13834== 
```
