### PR TITLE
Header files and libraries cannot be found if not installed to default directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ if (PISTACHE_INSTALL)
         "${Pistache_CONFIG_FILE}.in"
         "${CMAKE_CURRENT_BINARY_DIR}/${Pistache_CONFIG_FILE}"
         INSTALL_DESTINATION ${Pistache_CMAKE_INSTALL_PATH}
+        PATH_VARS include_install_dir lib_install_dir
     )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/${Pistache_CONFIG_FILE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,15 +29,21 @@ add_library(pistache_static STATIC $<TARGET_OBJECTS:pistache>)
 target_link_libraries(pistache_shared pthread)
 target_link_libraries(pistache_static pthread)
 
+set(Pistache_OUTPUT_NAME "pistache")
 set_target_properties(pistache_shared PROPERTIES
-    OUTPUT_NAME "pistache"
+    OUTPUT_NAME ${Pistache_OUTPUT_NAME}
     VERSION ${version}
     SOVERSION ${VERSION_MAJOR}
 )
 
-set_target_properties(pistache_static PROPERTIES OUTPUT_NAME "pistache")
+set_target_properties(pistache_static PROPERTIES 
+    OUTPUT_NAME ${Pistache_OUTPUT_NAME}
+)
 
 if (PISTACHE_INSTALL)
+    set(Pistache_CMAKE_INSTALL_PATH "lib/cmake/pistache")
+    set(Pistache_CONFIG_FILE "PistacheConfig.cmake")
+
     install(
       TARGETS pistache_shared
       EXPORT ${targets_export_name}
@@ -54,20 +60,20 @@ if (PISTACHE_INSTALL)
             EXPORT PistacheTargets
             DESTINATION lib)
     install(EXPORT PistacheTargets
-            DESTINATION "lib/cmake/pistache"
+            DESTINATION ${Pistache_CMAKE_INSTALL_PATH}
             EXPORT_LINK_INTERFACE_LIBRARIES
             COMPONENT cmake-config
     )
 
     include(CMakePackageConfigHelpers)
     configure_package_config_file(
-        "PistacheConfig.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/PistacheConfig.cmake"
-        INSTALL_DESTINATION "lib/cmake/pistache"
+        "${Pistache_CONFIG_FILE}.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/${Pistache_CONFIG_FILE}"
+        INSTALL_DESTINATION ${Pistache_CMAKE_INSTALL_PATH}
     )
     install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/PistacheConfig.cmake"
-        DESTINATION "lib/cmake/pistache"
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/${Pistache_CONFIG_FILE}"
+        DESTINATION ${Pistache_CMAKE_INSTALL_PATH}
         COMPONENT cmake-config
     )
 endif()

--- a/src/PistacheConfig.cmake.in
+++ b/src/PistacheConfig.cmake.in
@@ -1,3 +1,9 @@
 @PACKAGE_INIT@
 
+set_and_check ( Pistache_INCLUDE_DIRS "@PACKAGE_include_install_dir@")
+include_directories(${Pistache_INCLUDE_DIRS})
+
+set_and_check ( Pistache_LIBRARIES "@PACKAGE_lib_install_dir@")
+link_directories(${Pistache_LIBRARIES})
+
 include("${CMAKE_CURRENT_LIST_DIR}/PistacheTargets.cmake")


### PR DESCRIPTION
Hi,

I have noticed the following cmake issue in the pistache project:
If I am using the -DCMAKE_INSTALL_PREFIX during the cmake configuration to install the pistache libraries somewhere else (for example /opt/pistache) then my other projects will not find the libraries and the include files.

I was using the following example cmake with the rest_server.cc example from the pistache src-s:
```
cmake_minimum_required (VERSION 3.5)
project (TEST)

find_package(Pistache REQUIRED)

add_executable(${PROJECT_NAME}
    rest_server.cc
)
target_link_libraries(${PROJECT_NAME}
    pistache
    pthread
)
```

System spec:
* cmake 3.5 and cmake 3.12.2
* gcc 5.4
* Ubuntu 16.04.05 LTS

Please verify the issue. If you can reproduce it then you can find a solution suggestion in this pull request.