### PR TITLE
Fix issues in test_memcheck

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -205,18 +205,21 @@ private:
     struct ConnectionEntry {
         ConnectionEntry(
                 Async::Resolver resolve, Async::Rejection reject,
-                std::shared_ptr<Connection> connection, const struct sockaddr* addr, socklen_t addr_len)
+                std::shared_ptr<Connection> connection, const struct sockaddr* _addr, socklen_t _addr_len)
             : resolve(std::move(resolve))
             , reject(std::move(reject))
             , connection(connection)
-            , addr(addr)
-            , addr_len(addr_len)
-        { }
+        {
+            addr_len = _addr_len;
+            memcpy(&addr, _addr, addr_len);
+        }
+
+        const sockaddr *getAddr() { return reinterpret_cast<const sockaddr *>(&addr); }
 
         Async::Resolver resolve;
         Async::Rejection reject;
         std::weak_ptr<Connection> connection;
-        const struct sockaddr* addr;
+        sockaddr_storage addr;
         socklen_t addr_len;
     };
 

--- a/include/pistache/optional.h
+++ b/include/pistache/optional.h
@@ -168,7 +168,7 @@ public:
     Optional<T> &operator=(Optional<T> &&other)
       noexcept(types::is_nothrow_move_constructible<T>::value)
     {
-        if (other.data()) {
+        if (!other.isEmpty()) {
             move_helper(std::move(other), types::is_move_constructible<T>());
             other.none_flag = NoneMarker;
         }

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -7,6 +7,7 @@
 #include <pistache/client.h>
 #include <pistache/http.h>
 #include <pistache/stream.h>
+#include <pistache/net.h>
 
 #include <sys/sendfile.h>
 #include <netdb.h>
@@ -283,7 +284,7 @@ Transport::handleConnectionQueue() {
         if (!conn) {
             throw std::runtime_error("Connection error");
         }
-        int res = ::connect(conn->fd, data->addr, data->addr_len);
+        int res = ::connect(conn->fd, data->getAddr(), data->addr_len);
         if (res == -1) {
             if (errno == EINPROGRESS) {
                 reactor()->registerFdOneShot(key(), conn->fd, NotifyOn::Write | NotifyOn::Hangup | NotifyOn::Shutdown);
@@ -358,7 +359,6 @@ void
 Connection::connect(const Address& addr)
 {
     struct addrinfo hints;
-    struct addrinfo *addrs;
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family = addr.family();
     hints.ai_socktype = SOCK_STREAM; /* Stream socket */
@@ -367,11 +367,15 @@ Connection::connect(const Address& addr)
 
     const auto& host = addr.host();
     const auto& port = addr.port().toString();
-    TRY(::getaddrinfo(host.c_str(), port.c_str(), &hints, &addrs));
 
+    AddrInfo addressInfo;
+    
+    TRY(addressInfo.invoke(host.c_str(), port.c_str(), &hints));
+    const addrinfo *addrs = addressInfo.get_info_ptr();
+    
     int sfd = -1;
 
-    for (struct addrinfo *addr = addrs; addr; addr = addr->ai_next) {
+    for (const addrinfo *addr = addrs; addr; addr = addr->ai_next) {
         sfd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (sfd < 0) continue;
 

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -238,9 +238,7 @@ Address::init(const std::string& addr) {
         family_ = AF_INET6;
         try {
             in6_addr addr6;
-            char buff6[INET6_ADDRSTRLEN+1];
-            memcpy(buff6, host_.c_str(), INET6_ADDRSTRLEN);
-            inet_pton(AF_INET6, buff6, &(addr6.s6_addr16));
+            inet_pton(AF_INET6, host_.c_str(), &(addr6.s6_addr16));
         } catch (std::runtime_error) {
             throw std::invalid_argument("Invalid IPv6 address");
         }
@@ -257,9 +255,7 @@ Address::init(const std::string& addr) {
         }
         try {
             in_addr addr;
-            char buff[INET_ADDRSTRLEN+1];
-            memcpy(buff, host_.c_str(), INET_ADDRSTRLEN);
-            inet_pton(AF_INET, buff, &(addr));
+            inet_pton(AF_INET, host_.c_str(), &(addr));
         } catch (std::runtime_error) {
             throw std::invalid_argument("Invalid IPv4 address");
         }


### PR DESCRIPTION
Remaining issues in test_memcheck

Follow up for: https://github.com/oktal/pistache/issues/399
No issues remaining in 'test_memcheck' after this. (note: hopefully test coverage is sufficient)

1. include/pistache/async.h
- Memory leak - data allocated in 'Core' was never freed.

2.include/pistache/client.h
- Leak of ' const struct sockaddr* addr' - if the leak is fixed then this becomes an 'invalid read'
- Solution - make a local storage in the class and copy data over.

3. include/pistache/optional.h
- Uninitialized data read - data() is uninitialized if nothing was constructed there - the condition was dangerous - copied logic from normal operator= in same class.

4. src/client/client.cc
- Fix continuation for item 2.
- Fix actual leak source -> getaddrinfo leaked the 'addrs' - that needs to be freed. Good thing we have 'AddrInfo' class in pistache to do auto-cleanup when out of scope

5. src/common/net.cc
- Invalid read - buf may be smaller then 'INET6_ADDRSTRLEN' or the v4 version

6. src/common/transport.cc
- Dangling pointer - this is really scary, hopefully there aren't any others in the code.
- wq.pop_front(); - destroyes buffer which is just a reference to a reference: 
```
        auto & entry = wq.front();
        const BufferHolder &buffer = entry.buffer;
```
- code after that accessed buffer which was deleted.

