### PR TITLE
Fixing coverage support to compiler matrix and removed coverage of unnecessary files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-        packages: [ 'cmake', 'clang-4.0', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages: [ 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
 
   - os: linux
     compiler: clang
@@ -30,7 +30,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-        packages: [ 'cmake', 'clang-5.0', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages: [ 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
 
   - os: linux
     compiler: clang
@@ -41,7 +41,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-        packages: [ 'cmake', 'clang-6.0', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages: [ 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
 
   # Linux GCC builds
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- sudo su -c "echo 'if [ "\$1" = "-v" ] ; then \$COV_TOOL --version ; else \$COV_TOOL \$COV_TOOL_ARGS \$@ ; fi'" > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
+- sudo su -c "echo 'if [ \"\$1\" = \"-v\" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- sudo su -c "echo 'if [ $1 = "-v" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS $@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
+- sudo su -c "echo 'if [ $1 = "-v" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     env:
       - COMPILER=clang++-4.0
       - COV_TOOL=llvm-cov-4.0
+      - COV_TOOL_ARGS=gcov
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
@@ -24,7 +25,7 @@ matrix:
     compiler: clang
     env:
       - COMPILER=clang++-5.0
-      - COV_TOOL=llvm-cov-4.0
+      - COV_TOOL=llvm-cov-5.0
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
@@ -47,8 +48,8 @@ matrix:
     compiler: gcc
     env:
       - COMPILER=g++-4.9
-      - COV_TOOL=llvm-cov-4.0
-      - COV_TOOL_ARGS=gcov
+      - COV_TOOL=gcov
+      - COV_TOOL_ARGS=
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -56,7 +57,8 @@ matrix:
 
   - os: linux
     compiler: gcc
-    env: COMPILER=g++-5
+    env:
+      - COMPILER=g++-5
       - COV_TOOL=gcov-5
       - COV_TOOL_ARGS=
     addons:
@@ -66,7 +68,8 @@ matrix:
 
   - os: linux
     compiler: gcc
-    env: COMPILER=g++-6
+    env:
+      - COMPILER=g++-6
       - COV_TOOL=gcov-6
       - COV_TOOL_ARGS=
     addons:
@@ -76,7 +79,8 @@ matrix:
 
   - os: linux
     compiler: gcc
-    env: COMPILER=g++-7
+    env:
+      - COMPILER=g++-7
       - COV_TOOL=gcov-7
       - COV_TOOL_ARGS=
     addons:
@@ -86,7 +90,8 @@ matrix:
 
   - os: linux
     compiler: gcc
-    env: COMPILER=g++-8
+    env:
+      - COMPILER=g++-8
       - COV_TOOL=gcov-8
       - COV_TOOL_ARGS=
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,8 +127,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- export PISTACHE_SRC_ROOT=$(realpath $(pwd)/..)
 - lcov --capture --directory . --output-file coverage.info
-- lcov --remove coverage.info '/usr/*' "$PISTACHE_SRC_ROOT/test/*" "$PISTACHE_SRC_ROOT/googletest-release-1.7.0" --output-file coverage.info
+- lcov --remove coverage.info '/usr/*' "*test/*" "*googletest-release-1.7.0/*" -p ($pwd) --output-file coverage.info
 - lcov --list coverage.info
 - bash <(curl -s https://codecov.io/bash) -f coverage.info -t 1db5f955-be83-4bb5-8a8a-eeb4ad07ce11 || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     compiler: gcc
     env:
       - COMPILER=g++-4.9
-      - COV_TOOL=gcov
+      - COV_TOOL=gcov-4.9
       - COV_TOOL_ARGS=
     addons:
       apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- sudo su -c "echo '$COV_TOOL $COV_TOOL_ARGS \$@' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
+- sudo su -c "echo 'if [ $1 = "-v" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS $@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- sudo su -c "echo 'if [ $1 = "-v" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
+- sudo su -c "echo 'if [ "\$1" = "-v" ] ; then \$COV_TOOL --version ; else \$COV_TOOL \$COV_TOOL_ARGS \$@ ; fi'" > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,11 +146,8 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- cat << EOF > /usr/local/bin/cov-tool
-\#!/bin/bash
-$COV_TOOL $COV_TOOL_ARGS $@
-EOF
+- echo '$COV_TOOL $COV_TOOL_ARGS \$@' > /usr/local/bin/cov-tool && chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info
-- bash <(curl -s https://codecov.io/bash) -f coverage.info -t 1db5f955-be83-4bb5-8a8a-eeb4ad07ce11 || echo "Codecov did not collect coverage reports"
+- bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
   # Linux clang builds
   - os: linux
     compiler: clang
-    env: COMPILER=clang++-4.0
+    env:
+      - COMPILER=clang++-4.0
+      - COV_TOOL=llvm-cov-4.0
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
@@ -20,7 +22,10 @@ matrix:
 
   - os: linux
     compiler: clang
-    env: COMPILER=clang++-5.0
+    env:
+      - COMPILER=clang++-5.0
+      - COV_TOOL=llvm-cov-4.0
+      - COV_TOOL_ARGS=gcov
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
@@ -28,7 +33,10 @@ matrix:
 
   - os: linux
     compiler: clang
-    env: COMPILER=clang++-6.0
+    env:
+      - COMPILER=clang++-6.0
+      - COV_TOOL=llvm-cov-6.0
+      - COV_TOOL_ARGS=gcov
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
@@ -37,7 +45,10 @@ matrix:
   # Linux GCC builds
   - os: linux
     compiler: gcc
-    env: COMPILER=g++-4.9
+    env:
+      - COMPILER=g++-4.9
+      - COV_TOOL=llvm-cov-4.0
+      - COV_TOOL_ARGS=gcov
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -46,6 +57,8 @@ matrix:
   - os: linux
     compiler: gcc
     env: COMPILER=g++-5
+      - COV_TOOL=gcov-5
+      - COV_TOOL_ARGS=
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -54,6 +67,8 @@ matrix:
   - os: linux
     compiler: gcc
     env: COMPILER=g++-6
+      - COV_TOOL=gcov-6
+      - COV_TOOL_ARGS=
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -62,6 +77,8 @@ matrix:
   - os: linux
     compiler: gcc
     env: COMPILER=g++-7
+      - COV_TOOL=gcov-7
+      - COV_TOOL_ARGS=
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -70,6 +87,8 @@ matrix:
   - os: linux
     compiler: gcc
     env: COMPILER=g++-8
+      - COV_TOOL=gcov-8
+      - COV_TOOL_ARGS=
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
@@ -127,7 +146,11 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- lcov --capture --directory . --output-file coverage.info
-- lcov --remove coverage.info '/usr/*' "*test/*" "*googletest-release-1.7.0/*" -p ($pwd) --output-file coverage.info
+- cat << EOF > /usr/local/bin/cov-tool
+\#!/bin/bash
+$COV_TOOL $COV_TOOL_ARGS $@
+EOF
+- lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
+- lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info
 - bash <(curl -s https://codecov.io/bash) -f coverage.info -t 1db5f955-be83-4bb5-8a8a-eeb4ad07ce11 || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ after_failure:
 
 after_success:
 - cd ../Build-Debug
-- echo '$COV_TOOL $COV_TOOL_ARGS \$@' > /usr/local/bin/cov-tool && chmod +x /usr/local/bin/cov-tool
+- sudo su -c "echo '$COV_TOOL $COV_TOOL_ARGS \$@' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info
 - lcov --list coverage.info


### PR DESCRIPTION
Before this fix the coverage test was just passing in one of build jobs and there was unnecessary files inside tests/* and googletest-release-1.7.0/* folders. Supported compilers:

- clang-4.0 (error, maybe lcov version)
- clang-5.0 (error, maybe lcov version)
- clang-6.0 (error, maybe lcov version)
- g++-4.9 (done)
- g++-5 (done)
- g++-6 (done)
- g++-7 (done)
- g++-8 (error, maybe lcov version)