### PR TITLE
Changed .travis-ci.yml to test only on oficially supported compilers …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,9 +127,9 @@ matrix:
       - COMPILER_NAME=gcc
       - COMPILER_VERSION=4.9
 
-install:
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+# install:
+#   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+#   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
 before_script:
   # Bootraping environment and required packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-sudo: true
 
 branches:
   only:
@@ -126,10 +125,6 @@ matrix:
     env:
       - COMPILER_NAME=gcc
       - COMPILER_VERSION=4.9
-
-# install:
-#   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-#   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
 before_script:
   # Bootraping environment and required packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
           - 'gdb'
           - 'valgrind'
           - 'lcov'
-          - 'llvm-3.8-tools'
+          - 'llvm-3.8'
 
   - os: linux
     dist: trusty
@@ -387,7 +387,8 @@ install:
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
 before_script:
-  - export CXX=${COMPILER}
+  - export CXX=${CPP_COMPILER_BIN}
+  - export C=${C_COMPILER_BIN}
   - cd ${TRAVIS_BUILD_DIR}
 
   # Enable core dumps
@@ -408,6 +409,8 @@ before_script:
     -DPISTACHE_BUILD_EXAMPLES=true
     -DPISTACHE_BUILD_TESTS=true
     -DPISTACHE_SSL=true
+    -DCMAKE_C_COMPILER=$C_COMPILER_BIN
+    -DCMAKE_CXX_COMPILER=$CPP_COMPILER_BIN
 
   # Release build
   - cmake -H.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: cpp
-
-dist: trusty
 sudo: true
 
 branches:
@@ -9,95 +7,380 @@ branches:
 
 matrix:
   include:
-  # Linux clang builds
+
   - os: linux
+    dist: trusty
     compiler: clang
     env:
-      - COMPILER=clang++-4.0
+      - C_COMPILER_PACKAGE=clang-3.6
+      - C_COMPILER_BIN=clang-3.6
+      - CPP_COMPILER_PACKAGE=clang-3.6
+      - CPP_COMPILER_BIN=clang++-3.6
+      - COV_TOOL=llvm-cov-3.6
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'clang-3.6'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.6-tools'
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.8
+      - C_COMPILER_BIN=clang-3.8
+      - CPP_COMPILER_PACKAGE=clang-3.8
+      - CPP_COMPILER_BIN=clang++-3.8
+      - COV_TOOL=llvm-cov-3.8
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'clang-3.8'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.8-tools'
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.9
+      - C_COMPILER_BIN=clang-3.9
+      - CPP_COMPILER_PACKAGE=clang-3.9
+      - CPP_COMPILER_BIN=clang++-3.9
+      - COV_TOOL=llvm-cov-3.9
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'clang-3.9'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.9-tools'
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.4
+      - C_COMPILER_BIN=gcc-4.4
+      - CPP_COMPILER_PACKAGE=g++-4.4
+      - CPP_COMPILER_BIN=g++-4.4
+      - COV_TOOL=gcov-4.4
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'gcc-4.4'
+          - 'g++-4.4'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.6
+      - C_COMPILER_BIN=gcc-4.6
+      - CPP_COMPILER_PACKAGE=g++-4.6
+      - CPP_COMPILER_BIN=g++-4.6
+      - COV_TOOL=gcov-4.6
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'gcc-4.6'
+          - 'g++-4.6'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.7
+      - C_COMPILER_BIN=gcc-4.7
+      - CPP_COMPILER_PACKAGE=g++-4.7
+      - CPP_COMPILER_BIN=g++-4.7
+      - COV_TOOL=gcov-4.7
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'gcc-4.7'
+          - 'g++-4.7'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.8
+      - C_COMPILER_BIN=gcc-4.8
+      - CPP_COMPILER_PACKAGE=g++-4.8
+      - CPP_COMPILER_BIN=g++-4.8
+      - COV_TOOL=gcov-4.8
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake3'
+          - 'gcc-4.8'
+          - 'g++-4.8'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.5
+      - C_COMPILER_BIN=clang-3.5
+      - CPP_COMPILER_PACKAGE=clang-3.5
+      - CPP_COMPILER_BIN=clang++-3.5
+      - COV_TOOL=llvm-cov-3.5
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'clang-3.5'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.5-tools'
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.6
+      - C_COMPILER_BIN=clang-3.6
+      - CPP_COMPILER_PACKAGE=clang-3.6
+      - CPP_COMPILER_BIN=clang++-3.6
+      - COV_TOOL=llvm-cov-3.6
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'clang-3.6'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.6-tools'
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.7
+      - C_COMPILER_BIN=clang-3.7
+      - CPP_COMPILER_PACKAGE=clang-3.7
+      - CPP_COMPILER_BIN=clang++-3.7
+      - COV_TOOL=llvm-cov-3.7
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'clang-3.7'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.7-tools'
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-3.8
+      - C_COMPILER_BIN=clang-3.8
+      - CPP_COMPILER_PACKAGE=clang-3.8
+      - CPP_COMPILER_BIN=clang++-3.8
+      - COV_TOOL=llvm-cov-3.8
+      - COV_TOOL_ARGS=gcov
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'clang-3.8'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-3.8-tools'
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - C_COMPILER_PACKAGE=clang-4.0
+      - C_COMPILER_BIN=clang-4.0
+      - CPP_COMPILER_PACKAGE=clang-4.0
+      - CPP_COMPILER_BIN=clang++-4.0
       - COV_TOOL=llvm-cov-4.0
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-        packages: [ 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages:
+          - 'cmake'
+          - 'clang-4.0'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-4.0-tools'
 
   - os: linux
+    dist: xenial
     compiler: clang
     env:
-      - COMPILER=clang++-5.0
+      - C_COMPILER_PACKAGE=clang-5.0
+      - C_COMPILER_BIN=clang-5.0
+      - CPP_COMPILER_PACKAGE=clang-5.0
+      - CPP_COMPILER_BIN=clang++-5.0
       - COV_TOOL=llvm-cov-5.0
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-        packages: [ 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages:
+          - 'cmake'
+          - 'clang-5.0'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-5.0-tools'
 
   - os: linux
+    dist: xenial
     compiler: clang
     env:
-      - COMPILER=clang++-6.0
+      - C_COMPILER_PACKAGE=clang-6.0
+      - C_COMPILER_BIN=clang-6.0
+      - CPP_COMPILER_PACKAGE=clang-6.0
+      - CPP_COMPILER_BIN=clang++-6.0
       - COV_TOOL=llvm-cov-6.0
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-        packages: [ 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+        packages:
+          - 'cmake'
+          - 'clang-6.0'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+          - 'llvm-6.0-tools'
 
-  # Linux GCC builds
   - os: linux
+    dist: xenial
     compiler: gcc
     env:
-      - COMPILER=g++-4.9
+      - C_COMPILER_PACKAGE=gcc-4.7
+      - C_COMPILER_BIN=gcc-4.7
+      - CPP_COMPILER_PACKAGE=g++-4.7
+      - CPP_COMPILER_BIN=g++-4.7
+      - COV_TOOL=gcov-4.7
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'gcc-4.7'
+          - 'g++-4.7'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.8
+      - C_COMPILER_BIN=gcc-4.8
+      - CPP_COMPILER_PACKAGE=g++-4.8
+      - CPP_COMPILER_BIN=g++-4.8
+      - COV_TOOL=gcov-4.8
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        packages:
+          - 'cmake'
+          - 'gcc-4.8'
+          - 'g++-4.8'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - C_COMPILER_PACKAGE=gcc-4.9
+      - C_COMPILER_BIN=gcc-4.9
+      - CPP_COMPILER_PACKAGE=g++-4.9
+      - CPP_COMPILER_BIN=g++-4.9
       - COV_TOOL=gcov-4.9
       - COV_TOOL_ARGS=
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-4.9', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
-
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-5
-      - COV_TOOL=gcov-5
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-5', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
-
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-6
-      - COV_TOOL=gcov-6
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-6', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
-
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-7
-      - COV_TOOL=gcov-7
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-7', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
-
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-8
-      - COV_TOOL=gcov-8
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+        packages:
+          - 'cmake'
+          - 'gcc-4.9'
+          - 'g++-4.9'
+          - 'libssl-dev'
+          - 'libcurl4-openssl-dev'
+          - 'gdb'
+          - 'valgrind'
+          - 'lcov'
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"

--- a/.travis.yml
+++ b/.travis.yml
@@ -434,7 +434,6 @@ after_failure:
     gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 
-
 after_success:
 - cd ../Build-Debug
 - sudo su -c "echo 'if [ \"\$1\" = \"-v\" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool

--- a/.travis.yml
+++ b/.travis.yml
@@ -421,7 +421,7 @@ before_script:
 script:
   - # Debug build
   - cd Build-Debug
-  - make -j 2 all test ARGS="-V"
+  - make -j 2 all test ARGS="-V" VERBOSE=1
 
   - # Release build
   - cd ../Build-Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake3'
           - 'clang-3.6'
           - 'libssl-dev'
@@ -43,6 +44,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake3'
           - 'clang-3.8'
           - 'libssl-dev'
@@ -65,6 +67,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake3'
           - 'clang-3.9'
           - 'libssl-dev'
@@ -87,6 +90,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake3'
           - 'gcc-4.4'
           - 'g++-4.4'
@@ -109,6 +113,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake3'
           - 'gcc-4.6'
           - 'g++-4.6'
@@ -131,6 +136,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake3'
           - 'gcc-4.7'
           - 'g++-4.7'
@@ -153,6 +159,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake3'
           - 'gcc-4.8'
           - 'g++-4.8'
@@ -175,6 +182,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-3.5'
           - 'libssl-dev'
@@ -197,6 +205,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-3.6'
           - 'libssl-dev'
@@ -219,6 +228,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-3.7'
           - 'libssl-dev'
@@ -241,6 +251,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-3.8'
           - 'libssl-dev'
@@ -248,7 +259,7 @@ matrix:
           - 'gdb'
           - 'valgrind'
           - 'lcov'
-          - 'llvm-3.8-tools'
+          - 'llvm-3.8'
 
   - os: linux
     dist: xenial
@@ -263,6 +274,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-4.0'
           - 'libssl-dev'
@@ -285,6 +297,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-5.0'
           - 'libssl-dev'
@@ -307,6 +320,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libc++-dev'
           - 'cmake'
           - 'clang-6.0'
           - 'libssl-dev'
@@ -329,6 +343,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake'
           - 'gcc-4.7'
           - 'g++-4.7'
@@ -351,6 +366,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake'
           - 'gcc-4.8'
           - 'g++-4.8'
@@ -373,6 +389,7 @@ matrix:
     addons:
       apt:
         packages:
+          - 'libstdc++6-4.7-dev'
           - 'cmake'
           - 'gcc-4.9'
           - 'g++-4.9'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,437 +12,138 @@ matrix:
     dist: trusty
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.6
-      - C_COMPILER_BIN=clang-3.6
-      - CPP_COMPILER_PACKAGE=clang-3.6
-      - CPP_COMPILER_BIN=clang++-3.6
-      - COV_TOOL=llvm-cov-3.6
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake3'
-          - 'clang-3.6'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.6-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.6
 
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.8
-      - C_COMPILER_BIN=clang-3.8
-      - CPP_COMPILER_PACKAGE=clang-3.8
-      - CPP_COMPILER_BIN=clang++-3.8
-      - COV_TOOL=llvm-cov-3.8
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake3'
-          - 'clang-3.8'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.8'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.8
 
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.9
-      - C_COMPILER_BIN=clang-3.9
-      - CPP_COMPILER_PACKAGE=clang-3.9
-      - CPP_COMPILER_BIN=clang++-3.9
-      - COV_TOOL=llvm-cov-3.9
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake3'
-          - 'clang-3.9'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.9-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.9
 
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.4
-      - C_COMPILER_BIN=gcc-4.4
-      - CPP_COMPILER_PACKAGE=g++-4.4
-      - CPP_COMPILER_BIN=g++-4.4
-      - COV_TOOL=gcov-4.4
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake3'
-          - 'gcc-4.4'
-          - 'g++-4.4'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.4
 
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.6
-      - C_COMPILER_BIN=gcc-4.6
-      - CPP_COMPILER_PACKAGE=g++-4.6
-      - CPP_COMPILER_BIN=g++-4.6
-      - COV_TOOL=gcov-4.6
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake3'
-          - 'gcc-4.6'
-          - 'g++-4.6'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.6
 
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.7
-      - C_COMPILER_BIN=gcc-4.7
-      - CPP_COMPILER_PACKAGE=g++-4.7
-      - CPP_COMPILER_BIN=g++-4.7
-      - COV_TOOL=gcov-4.7
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake3'
-          - 'gcc-4.7'
-          - 'g++-4.7'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.7
 
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.8
-      - C_COMPILER_BIN=gcc-4.8
-      - CPP_COMPILER_PACKAGE=g++-4.8
-      - CPP_COMPILER_BIN=g++-4.8
-      - COV_TOOL=gcov-4.8
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake3'
-          - 'gcc-4.8'
-          - 'g++-4.8'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.8
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.5
-      - C_COMPILER_BIN=clang-3.5
-      - CPP_COMPILER_PACKAGE=clang-3.5
-      - CPP_COMPILER_BIN=clang++-3.5
-      - COV_TOOL=llvm-cov-3.5
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-3.5'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.5-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.5
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.6
-      - C_COMPILER_BIN=clang-3.6
-      - CPP_COMPILER_PACKAGE=clang-3.6
-      - CPP_COMPILER_BIN=clang++-3.6
-      - COV_TOOL=llvm-cov-3.6
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-3.6'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.6-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.6
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.7
-      - C_COMPILER_BIN=clang-3.7
-      - CPP_COMPILER_PACKAGE=clang-3.7
-      - CPP_COMPILER_BIN=clang++-3.7
-      - COV_TOOL=llvm-cov-3.7
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-3.7'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.7-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.7
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-3.8
-      - C_COMPILER_BIN=clang-3.8
-      - CPP_COMPILER_PACKAGE=clang-3.8
-      - CPP_COMPILER_BIN=clang++-3.8
-      - COV_TOOL=llvm-cov-3.8
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-3.8'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-3.8'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.8
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-4.0
-      - C_COMPILER_BIN=clang-4.0
-      - CPP_COMPILER_PACKAGE=clang-4.0
-      - CPP_COMPILER_BIN=clang++-4.0
-      - COV_TOOL=llvm-cov-4.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-4.0'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-4.0-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=4.0
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-5.0
-      - C_COMPILER_BIN=clang-5.0
-      - CPP_COMPILER_PACKAGE=clang-5.0
-      - CPP_COMPILER_BIN=clang++-5.0
-      - COV_TOOL=llvm-cov-5.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-5.0'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-5.0-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=5.0
 
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - C_COMPILER_PACKAGE=clang-6.0
-      - C_COMPILER_BIN=clang-6.0
-      - CPP_COMPILER_PACKAGE=clang-6.0
-      - CPP_COMPILER_BIN=clang++-6.0
-      - COV_TOOL=llvm-cov-6.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        packages:
-          - 'libc++-dev'
-          - 'cmake'
-          - 'clang-6.0'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
-          - 'llvm-6.0-tools'
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=6.0
 
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.7
-      - C_COMPILER_BIN=gcc-4.7
-      - CPP_COMPILER_PACKAGE=g++-4.7
-      - CPP_COMPILER_BIN=g++-4.7
-      - COV_TOOL=gcov-4.7
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake'
-          - 'gcc-4.7'
-          - 'g++-4.7'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.7
 
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.8
-      - C_COMPILER_BIN=gcc-4.8
-      - CPP_COMPILER_PACKAGE=g++-4.8
-      - CPP_COMPILER_BIN=g++-4.8
-      - COV_TOOL=gcov-4.8
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake'
-          - 'gcc-4.8'
-          - 'g++-4.8'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.8
 
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - C_COMPILER_PACKAGE=gcc-4.9
-      - C_COMPILER_BIN=gcc-4.9
-      - CPP_COMPILER_PACKAGE=g++-4.9
-      - CPP_COMPILER_BIN=g++-4.9
-      - COV_TOOL=gcov-4.9
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        packages:
-          - 'libstdc++6-4.7-dev'
-          - 'cmake'
-          - 'gcc-4.9'
-          - 'g++-4.9'
-          - 'libssl-dev'
-          - 'libcurl4-openssl-dev'
-          - 'gdb'
-          - 'valgrind'
-          - 'lcov'
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.9
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
 before_script:
-  - export CXX=${CPP_COMPILER_BIN}
-  - export C=${C_COMPILER_BIN}
-  - cd ${TRAVIS_BUILD_DIR}
-
-  # Enable core dumps
-  - ulimit -c
-  - ulimit -a -S
-  - ulimit -a -H
-
-  # Print debug system information
-  - cat /proc/sys/kernel/core_pattern
-  - cat /etc/default/apport
-  - service --status-all || true
-  - initctl list || true
-
-  # Debug build
-  - cmake -H.
-    -BBuild-Debug
-    -DCMAKE_BUILD_TYPE=Debug
-    -DPISTACHE_BUILD_EXAMPLES=true
-    -DPISTACHE_BUILD_TESTS=true
-    -DPISTACHE_SSL=true
-    -DCMAKE_C_COMPILER=$C_COMPILER_BIN
-    -DCMAKE_CXX_COMPILER=$CPP_COMPILER_BIN
-
-  # Release build
-  - cmake -H.
-    -BBuild-Release
-    -DCMAKE_BUILD_TYPE=Release
-    -DPISTACHE_SSL=true
+  # Bootraping environment and required packages
+  - . bootstrap-env.bash
+  - ./bootstrap.bash
 
 script:
-  - # Debug build
-  - cd Build-Debug
-  - make -j 2 all test ARGS="-V" VERBOSE=1
+  # Debug build
+  - cd build/debug
+  - make -j $(nproc) all test ARGS="-V"
 
-  - # Release build
-  - cd ../Build-Release
-  - make -j 2
+  # Release build
+  - cd ../build/release
+  - make -j $(nproc)
 
 after_failure:
   - ls -lta /var/crash
@@ -451,8 +152,9 @@ after_failure:
     gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 
+
 after_success:
-- cd ../Build-Debug
+- cd ../build/debug
 - sudo su -c "echo 'if [ \"\$1\" = \"-v\" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ else()
     # This gives an error on date.h external library.
     # Following workaround forces Clang to compile at best with C++14
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         set(CMAKE_CXX_STANDARD 14)
     elseif (CMAKE_COMPILER_IS_GNUCC)
         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)

--- a/bootstrap-env.bash
+++ b/bootstrap-env.bash
@@ -1,5 +1,23 @@
 #!/bin/bash -ve
 
+cat << EOF > /etc/apt/sources.list.d/llvm.list
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main
+deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty main
+# 7 
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main
+deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main
+# 8 
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main
+deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main
+
+# Also add the following for the appropriate libstdc++
+# LLVM toolchain trusts ubuntu-toolchain-r/test as libstdc++ reference
+# Trusty repository is broken as this open issue shows https://github.com/stan-dev/math/issues/604
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main
+EOF
+
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
+
 sudo apt-get update
 
 if [[ "$COMPILER_NAME" = "clang" ]]; then
@@ -11,7 +29,7 @@ if [[ "$COMPILER_NAME" = "clang" ]]; then
     if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION-tools)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
     if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
     export COV_TOOL_ARGS=gcov
-    export CPP_STDLIB_PACKAGE=libc++-dev
+    export CPP_STDLIB_PACKAGE=libc++-$COMPILER_VERSION-dev
 elif [[ "$COMPILER_NAME" = "gcc" ]]; then
     export C_COMPILER_PACKAGE=gcc-$COMPILER_VERSION
     export C_COMPILER_BIN=gcc-$COMPILER_VERSION

--- a/bootstrap-env.bash
+++ b/bootstrap-env.bash
@@ -25,4 +25,4 @@ fi
 
 export CC=$C_COMPILER_BIN
 export CXX=$CPP_COMPILER_BIN
-export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/bootstrap-env.bash
+++ b/bootstrap-env.bash
@@ -1,0 +1,28 @@
+#!/bin/bash -ve
+
+apt-get update
+
+if [[ "$COMPILER_NAME" = "clang" ]]; then
+    export C_COMPILER_PACKAGE=clang-$COMPILER_VERSION
+    export C_COMPILER_BIN=clang-$COMPILER_VERSION
+    export CPP_COMPILER_PACKAGE=
+    export CPP_COMPILER_BIN=clang++-$COMPILER_VERSION
+    export COV_TOOL_BIN=llvm-cov-$COMPILER_VERSION
+    if [ ! -z "$(apt-cache search llvm-$COMPILER_VERSION-tools)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
+    if [ ! -z "$(apt-cache search llvm-$COMPILER_VERSION)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
+    export COV_TOOL_ARGS=gcov
+    export CPP_STDLIB_PACKAGE=libc++-dev
+elif [[ "$COMPILER_NAME" = "gcc" ]]; then
+    export C_COMPILER_PACKAGE=gcc-$COMPILER_VERSION
+    export C_COMPILER_BIN=gcc-$COMPILER_VERSION
+    export CPP_COMPILER_PACKAGE=g++-$COMPILER_VERSION
+    export CPP_COMPILER_BIN=g++-$COMPILER_VERSION
+    export COV_TOOL_BIN=gcov-$COMPILER_VERSION
+    export COV_TOOL_PACKAGE=gcov-$COMPILER_VERSION
+    export COV_TOOL_ARGS=
+    export CPP_STDLIB_PACKAGE=
+fi
+
+export CC=$C_COMPILER_BIN
+export CXX=$CPP_COMPILER_BIN
+export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/bootstrap-env.bash
+++ b/bootstrap-env.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ve
 
-apt-get update
+sudo apt-get update
 
 if [[ "$COMPILER_NAME" = "clang" ]]; then
     export C_COMPILER_PACKAGE=clang-$COMPILER_VERSION
@@ -8,8 +8,8 @@ if [[ "$COMPILER_NAME" = "clang" ]]; then
     export CPP_COMPILER_PACKAGE=
     export CPP_COMPILER_BIN=clang++-$COMPILER_VERSION
     export COV_TOOL_BIN=llvm-cov-$COMPILER_VERSION
-    if [ ! -z "$(apt-cache search llvm-$COMPILER_VERSION-tools)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
-    if [ ! -z "$(apt-cache search llvm-$COMPILER_VERSION)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
+    if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION-tools)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
+    if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION)" ]; then export COV_TOOL_PACKAGE=$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools; fi
     export COV_TOOL_ARGS=gcov
     export CPP_STDLIB_PACKAGE=libc++-dev
 elif [[ "$COMPILER_NAME" = "gcc" ]]; then

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,0 +1,41 @@
+#!/bin/bash -ve
+
+cd $DIR
+
+apt-get update
+
+apt-get install -y coreutils apparmor-profiles libssl-dev libcurl4-openssl-dev gdb valgrind lcov python-pip python3-pip git $C_COMPILER_PACKAGE $CPP_COMPILER_PACKAGE $CPP_STDLIB_PACKAGE
+
+python -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
+
+pip3 install cmake
+
+git submodule update --init --recursive
+
+# Enable core dumps
+ulimit -c
+ulimit -a -S
+ulimit -a -H
+
+# Print debug system information
+cat /proc/sys/kernel/core_pattern
+cat /etc/default/apport || true
+service --status-all || true
+initctl list || true
+
+# Debug build
+cmake -B$DIR/build/debug \
+    -DCMAKE_BUILD_TYPE=debug \
+    -DPISTACHE_BUILD_EXAMPLES=true \
+    -DPISTACHE_BUILD_TESTS=true \
+    -DPISTACHE_SSL=true \
+    -DCMAKE_C_COMPILER=$CC \
+    -DCMAKE_CXX_COMPILER=$CXX
+
+# Release build
+cmake -B$DIR/build/release \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPISTACHE_SSL=true \
+    -DCMAKE_C_COMPILER=$CC \
+    -DCMAKE_CXX_COMPILER=$CXX

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -28,11 +28,11 @@ cmake -B$PROJECT_DIR/build/debug \
     -DPISTACHE_BUILD_TESTS=true \
     -DPISTACHE_SSL=true \
     -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX
+    -DCMAKE_CXX_COMPILER=$CXX .
 
 # Release build
 cmake -B$PROJECT_DIR/build/release \
     -DCMAKE_BUILD_TYPE=Release \
     -DPISTACHE_SSL=true \
     -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX
+    -DCMAKE_CXX_COMPILER=$CXX .

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -1,17 +1,14 @@
 #!/bin/bash -ve
 
-cd $DIR
+cd $PROJECT_DIR
 
 sudo apt-get update
-
 sudo apt-get install -y coreutils apparmor-profiles libssl-dev libcurl4-openssl-dev gdb valgrind lcov python-pip python3-pip git $C_COMPILER_PACKAGE $CPP_COMPILER_PACKAGE $CPP_STDLIB_PACKAGE
 
 sudo python -m pip install --upgrade pip
 sudo python3 -m pip install --upgrade pip
 
 sudo pip3 install cmake
-
-git submodule update --init --recursive
 
 # Enable core dumps
 ulimit -c

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -2,14 +2,14 @@
 
 cd $DIR
 
-apt-get update
+sudo apt-get update
 
-apt-get install -y coreutils apparmor-profiles libssl-dev libcurl4-openssl-dev gdb valgrind lcov python-pip python3-pip git $C_COMPILER_PACKAGE $CPP_COMPILER_PACKAGE $CPP_STDLIB_PACKAGE
+sudo apt-get install -y coreutils apparmor-profiles libssl-dev libcurl4-openssl-dev gdb valgrind lcov python-pip python3-pip git $C_COMPILER_PACKAGE $CPP_COMPILER_PACKAGE $CPP_STDLIB_PACKAGE
 
-python -m pip install --upgrade pip
-python3 -m pip install --upgrade pip
+sudo python -m pip install --upgrade pip
+sudo python3 -m pip install --upgrade pip
 
-pip3 install cmake
+sudo pip3 install cmake
 
 git submodule update --init --recursive
 
@@ -25,7 +25,7 @@ service --status-all || true
 initctl list || true
 
 # Debug build
-cmake -B$DIR/build/debug \
+cmake -B$PROJECT_DIR/build/debug \
     -DCMAKE_BUILD_TYPE=debug \
     -DPISTACHE_BUILD_EXAMPLES=true \
     -DPISTACHE_BUILD_TESTS=true \
@@ -34,7 +34,7 @@ cmake -B$DIR/build/debug \
     -DCMAKE_CXX_COMPILER=$CXX
 
 # Release build
-cmake -B$DIR/build/release \
+cmake -B$PROJECT_DIR/build/release \
     -DCMAKE_BUILD_TYPE=Release \
     -DPISTACHE_SSL=true \
     -DCMAKE_C_COMPILER=$CC \

--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -22,17 +22,17 @@ service --status-all || true
 initctl list || true
 
 # Debug build
-cmake -B$PROJECT_DIR/build/debug \
+cmake -Bbuild/debug \
     -DCMAKE_BUILD_TYPE=debug \
     -DPISTACHE_BUILD_EXAMPLES=true \
     -DPISTACHE_BUILD_TESTS=true \
     -DPISTACHE_SSL=true \
     -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX .
+    -DCMAKE_CXX_COMPILER=$CXX $PROJECT_DIR
 
 # Release build
-cmake -B$PROJECT_DIR/build/release \
+cmake -Bbuild/release \
     -DCMAKE_BUILD_TYPE=Release \
     -DPISTACHE_SSL=true \
     -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX .
+    -DCMAKE_CXX_COMPILER=$CXX $PROJECT_DIR


### PR DESCRIPTION
Currently this project is not using officially supported compilers to test it. The continuous integration process is using a [Personal Package Archive](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test) from [Matthias Klose](Matthias Klose) a community contributor to Ubuntu distribution. So I removed this dependency and used officially supported g++ and clang packages from trusty and xenial distros in the matrix.

This pull request is intented to test this new approach to continuous integration. I should review the results before testing. Please do not merge now. Yet there are missing features like using different vrsions of libstdc++ and libc++ (llvm implementation of c++ standard library).