### PR TITLE
Fixing case where const was cast away

### DIFF
--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -189,7 +189,7 @@ public:
     }
 
     Buffer buffer() const {
-        return Buffer((char*) data_.data(), pptr() - &data_[0]);
+        return Buffer((const char*) data_.data(), pptr() - &data_[0]);
     }
 
     void clear() {


### PR DESCRIPTION
Small fix to allow compilation with gcc's -Wcast-qual warning, and treating all warnings as errors.