### PR TITLE
Attempt to fix HTTP connection header handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ build
 *.exe
 *.out
 *.app
+
+# Ignoring IDE files
+
+.vscode
+.idea

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -85,10 +85,13 @@ protected:
     Version version_;
     Code code_;
 
-    Header::Collection headers_;
+
     std::string body_;
 
     CookieJar cookies_;
+    Header::Collection headers_;
+public:
+
 };
 
 namespace Uri {

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -810,6 +810,7 @@ Client::doRequest(
         Http::Request request,
         std::chrono::milliseconds timeout)
 {
+    //request.headers_.add<Header::Connection>(ConnectionControl::KeepAlive);
     request.headers_.remove<Header::UserAgent>();
     auto resource = request.resource();
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -605,8 +605,8 @@ ResponseStream::ResponseStream(
          * Correctly handle non-keep alive requests
          * Do not put Keep-Alive if version == Http::11 and request.keepAlive == true
         */
-        writeHeader<Header::Connection>(os, ConnectionControl::KeepAlive);
-        if (!os) throw Error("Response exceeded buffer size");
+        // writeHeader<Header::Connection>(os, ConnectionControl::KeepAlive);
+        // if (!os) throw Error("Response exceeded buffer size");
         writeHeader<Header::TransferEncoding>(os, Header::Encoding::Chunked);
         if (!os) throw Error("Response exceeded buffer size");
         os << crlf;
@@ -659,7 +659,7 @@ ResponseWriter::putOnWire(const char* data, size_t len)
          * Correctly handle non-keep alive requests
          * Do not put Keep-Alive if version == Http::11 and request.keepAlive == true
         */
-        OUT(writeHeader<Header::Connection>(os, ConnectionControl::KeepAlive));
+        //OUT(writeHeader<Header::Connection>(os, ConnectionControl::KeepAlive));
         OUT(writeHeader<Header::ContentLength>(os, len));
 
         OUT(os << crlf);
@@ -675,7 +675,17 @@ ResponseWriter::putOnWire(const char* data, size_t len)
 #undef OUT
 
         auto fd = peer()->fd();
-        return transport_->asyncWrite(fd, buffer);
+
+        return transport_->asyncWrite(fd, buffer)
+         .then
+                 <
+                         std::function< Async::Promise<ssize_t>(int)>,
+                         std::function<void(std::exception_ptr&)>
+                 >
+                 (
+                         [=](int l) { return Async::Promise<ssize_t>([=](Async::Deferred<ssize_t> deferred) mutable { close(peer()->fd()); }); },
+                         [=](std::exception_ptr& eptr){}
+                 );
 
     } catch (const std::runtime_error& e) {
         return Async::Promise<ssize_t>::rejected(e);
@@ -768,6 +778,7 @@ Handler::onInput(const char* buffer, size_t len, const std::shared_ptr<Tcp::Peer
         }
 
         auto state = parser.parse();
+
         if (state == Private::State::Done) {
             ResponseWriter response(transport(), parser.request, this);
             response.associatePeer(peer);
@@ -775,15 +786,29 @@ Handler::onInput(const char* buffer, size_t len, const std::shared_ptr<Tcp::Peer
 #ifdef LIBSTDCPP_SMARTPTR_LOCK_FIXME
             parser.request.associatePeer(peer);
 #endif
-            onRequest(parser.request, std::move(response));
+
+            auto request = parser.request;
+            auto connection = request.headers().tryGet<Header::Connection>();
+
+            if (connection) {
+                response.headers()
+                    .add<Header::Connection>(connection->control());
+            } else {
+                response.headers()
+                        .add<Header::Connection>(ConnectionControl::Close);
+            }
+
+            onRequest(request, std::move(response));
             parser.reset();
         }
+
     } catch (const HttpError &err) {
         ResponseWriter response(transport(), parser.request, this);
         response.associatePeer(peer);
         response.send(static_cast<Code>(err.code()), err.reason());
         parser.reset();
     }
+
     catch (const std::exception& e) {
         ResponseWriter response(transport(), parser.request, this);
         response.associatePeer(peer);

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -683,7 +683,18 @@ ResponseWriter::putOnWire(const char* data, size_t len)
                          std::function<void(std::exception_ptr&)>
                  >
                  (
-                         [=](int l) { return Async::Promise<ssize_t>([=](Async::Deferred<ssize_t> deferred) mutable { close(peer()->fd()); }); },
+                         [=](int l) {
+                             return Async::Promise<ssize_t>([=](Async::Deferred<ssize_t> deferred) mutable {
+                                 auto connection = this->headers().tryGet<Header::Connection>();
+                                 if (connection) {
+                                     if (connection->control() == ConnectionControl::KeepAlive ) return;
+                                 }
+
+                                 close(peer()->fd());
+                                return;
+                             });
+                         },
+
                          [=](std::exception_ptr& eptr){}
                  );
 

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -48,7 +48,7 @@ TEST(http_client_test, one_client_with_one_request)
     client.init();
 
     auto rb = client.get(server_address);
-    auto response = rb.send();
+    auto response = rb.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
     bool done = false;
     response.then([&](Http::Response rsp)
                   {
@@ -87,7 +87,7 @@ TEST(http_client_test, one_client_with_multiple_requests) {
 
     auto rb = client.get(server_address);
     for (int i = 0; i < RESPONSE_SIZE; ++i) {
-        auto response = rb.send();
+        auto response = rb.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
         response.then([&](Http::Response rsp) {
             if (rsp.code() == Http::Code::Ok)
                 ++response_counter;
@@ -131,21 +131,21 @@ TEST(http_client_test, multiple_clients_with_one_request) {
     std::atomic<int> response_counter(0);
 
     auto rb1 = client1.get(server_address);
-    auto response1 = rb1.send();
+    auto response1 = rb1.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
     response1.then([&](Http::Response rsp) {
             if (rsp.code() == Http::Code::Ok)
                 ++response_counter;
         }, Async::IgnoreException);
     responses.push_back(std::move(response1));
     auto rb2 = client2.get(server_address);
-    auto response2 = rb2.send();
+    auto response2 = rb2.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
     response2.then([&](Http::Response rsp) {
             if (rsp.code() == Http::Code::Ok)
                 ++response_counter;
         }, Async::IgnoreException);
     responses.push_back(std::move(response2));
     auto rb3 = client3.get(server_address);
-    auto response3 = rb3.send();
+    auto response3 = rb3.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
     response3.then([&](Http::Response rsp) {
             if (rsp.code() == Http::Code::Ok)
                 ++response_counter;
@@ -183,7 +183,7 @@ TEST(http_client_test, timeout_reject)
     client.init();
 
     auto rb = client.get(server_address).timeout(std::chrono::milliseconds(1000));
-    auto response = rb.send();
+    auto response = rb.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
     bool is_reject = false;
     response.then([&is_reject](Http::Response /*rsp*/)
                   {
@@ -228,7 +228,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_
     auto rb = client.get(server_address);
     for (int i = 0; i < RESPONSE_SIZE; ++i)
     {
-        auto response = rb.send();
+        auto response = rb.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
         response.then([&](Http::Response rsp)
                       {
                           if (rsp.code() == Http::Code::Ok)
@@ -274,7 +274,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_two_connections_per
     auto rb = client.get(server_address);
     for (int i = 0; i < RESPONSE_SIZE; ++i)
     {
-        auto response = rb.send();
+        auto response = rb.header<Http::Header::Connection>(Http::ConnectionControl::KeepAlive).send();
         response.then([&](Http::Response rsp)
                       {
                           if (rsp.code() == Http::Code::Ok)


### PR DESCRIPTION
When client requests

keep-alive: the answer from the server is keep-alive and the connection remains open
close: the answer from the server is close and connection is closed
ext: the answer from the server is ext and connection is closed (I don't really know what exactly should be the behaviour of the server when connection is like this; so this follows default: close connection).

When no Connection header is specified the server closed the connection by default.