### PR TITLE
fix: -Wreorder warning on gcc

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -85,12 +85,10 @@ protected:
     Version version_;
     Code code_;
 
-
     std::string body_;
 
     CookieJar cookies_;
     Header::Collection headers_;
-public:
 
 };
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -477,9 +477,9 @@ namespace Private {
 Message::Message()
     : version_(Version::Http11)
     , code_()
-    , headers_()
     , body_()
     , cookies_()
+    , headers_()
 { }
 
 namespace Uri {


### PR DESCRIPTION
Hi,
on building Pistache I always get a -Wreorder warning in gcc. Here is a fix to get rid of it. 