### PR TITLE
Fix memory leak in client: lambda holds shared_ptr

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -282,8 +282,10 @@ Transport::handleConnectionQueue() {
 
         auto conn = data->connection.lock();
         if (!conn) {
-            throw std::runtime_error("Connection error: problem with establishing connection to server");
+            data->reject(Error::system("Failed to connect"));
+            continue;
         }
+
         int res = ::connect(conn->fd(), data->getAddr(), data->addr_len);
         if (res == -1) {
             if (errno == EINPROGRESS) {


### PR DESCRIPTION
Fix memory leak in client: lambda holds shared_ptr and memory isn't freed (Connection)