### PR TITLE
Exposing Router::addRoute

### DIFF
--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -225,6 +225,7 @@ public:
     void patch(const std::string& resource, Route::Handler handler);
     void del(const std::string& resource, Route::Handler handler);
     void options(const std::string& resource, Route::Handler handler);
+    void addRoute(Http::Method method, const std::string& resource, Route::Handler handler);
     void removeRoute(Http::Method method, const std::string& resource);
 
     void addCustomHandler(Route::Handler handler);
@@ -242,9 +243,6 @@ public:
     { }
 
 private:
-
-    void addRoute(Http::Method method, const std::string& resource,
-                  Route::Handler handler);
 
     std::unordered_map<Http::Method, SegmentTreeNode> routes;
 

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -449,8 +449,7 @@ Router::route(const Http::Request& req, Http::ResponseWriter response) {
     return Route::Status::NotFound;
 }
 
-void Router::addRoute(Http::Method method,
-    const std::string& resource, Route::Handler handler) {
+void Router::addRoute(Http::Method method, const std::string& resource, Route::Handler handler) {
     if (resource.empty()) throw std::runtime_error("Invalid zero-length URL.");
     auto& r = routes[method];
     const auto sanitized = SegmentTreeNode::sanitizeResource(resource);


### PR DESCRIPTION
This improvement could simplify adding routes at runtime from a dynamically loaded module.

Instead of classifying routes by method by method through a conditional statement. This could simplify, just by creating a dictionary of routes and adding strongly typed method information to it.