### PR TITLE
Fixing error handling in client and payload test

### DIFF
--- a/tests/payload_test.cc
+++ b/tests/payload_test.cc
@@ -36,20 +36,28 @@ struct TestSet {
 
 using PayloadTestSets = std::vector<TestSet>;
 
-void testPayloads(Http::Client& client, const std::string& url, const PayloadTestSets& testPayloads) {
-   // Client tests to make sure the payload is enforced
+void testPayloads(const std::string& url, const PayloadTestSets& testPayloads) {
+    // Client tests to make sure the payload is enforced
+    PayloadTestSets testResults;
     std::mutex resultsetMutex;
-    PayloadTestSets test_results;
+
+    Http::Client client;
+    auto client_opts = Http::Client::options()
+        .threads(3)
+        .maxConnectionsPerHost(3);
+    client.init(client_opts);
+
     std::vector<Async::Promise<Http::Response>> responses;
+    responses.reserve(testPayloads.size());
     for (auto & t : testPayloads) {
         std::string payload(t.bytes, 'A');
         auto response = client.post(url).body(payload).timeout(std::chrono::seconds(wait_time)).send();
-        response.then([t,&test_results,&resultsetMutex](Http::Response rsp) {
+        response.then([t,&testResults,&resultsetMutex](Http::Response rsp) {
                 TestSet res(t);
                 res.actualCode = rsp.code();
                 {
                     std::unique_lock<std::mutex> lock(resultsetMutex);
-                    test_results.push_back(res);
+                    testResults.push_back(res);
                 }
                 }, Async::IgnoreException);
         responses.push_back(std::move(response));
@@ -59,9 +67,11 @@ void testPayloads(Http::Client& client, const std::string& url, const PayloadTes
     Async::Barrier<std::vector<Http::Response>> barrier(sync);
     barrier.wait_for(std::chrono::seconds(2*wait_time));
 
-    for (auto & result : test_results) {
+    for (auto & result : testResults) {
         ASSERT_EQ(result.expectedCode, result.actualCode);
     }
+
+    client.shutdown();
 }
 
 void handleEcho(const Rest::Request& /*request*/, Http::ResponseWriter response) {
@@ -95,13 +105,6 @@ TEST(payload, from_description)
     endpoint->setHandler(router.handler());
     endpoint->serveThreaded();
 
-
-    Http::Client client;
-    auto client_opts = Http::Client::options()
-        .threads(3)
-        .maxConnectionsPerHost(3);
-    client.init(client_opts);
-
     // TODO: Remove temp hack once 'serveThreaded()' waits for socket to be
     // created before returning.
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
@@ -113,9 +116,8 @@ TEST(payload, from_description)
         ,{2048, Http::Code::Request_Entity_Too_Large}
     };
 
-    testPayloads(client, "127.0.0.1:" + std::to_string(port), payloads);
+    testPayloads("127.0.0.1:" + std::to_string(port), payloads);
 
-    client.shutdown();
     endpoint->shutdown();
 }
 
@@ -156,22 +158,14 @@ TEST(payload, manual_construction) {
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
     const auto port = endpoint->getPort();
 
-    // Create http client.
-    Http::Client client;
-    auto client_opts = Http::Client::options()
-        .threads(3)
-        .maxConnectionsPerHost(3);
-    client.init(client_opts);
-
     PayloadTestSets payloads{
        {1024, Http::Code::Ok}
        , {1800, Http::Code::Ok}
        , {2048, Http::Code::Request_Entity_Too_Large}
        , {4096, Http::Code::Request_Entity_Too_Large}
     };
-    testPayloads(client, "127.0.0.1:" + std::to_string(port), payloads);
 
-    // Cleanup
-    client.shutdown();
+    testPayloads("127.0.0.1:" + std::to_string(port), payloads);
+
     endpoint->shutdown();
 }


### PR DESCRIPTION
In payload_test `client` and `resultsetMutex` should be in the same scope because `resultsetMutex` is captured by lambda that can be call during client desctruction.