### PR TITLE
Refactoing in Client and Epoll

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -260,6 +260,9 @@ private:
 
     void handleRequestsQueue();
     void handleConnectionQueue();
+    void handleReadableEntry(const Aio::FdSet::Entry& entry);
+    void handleWritableEntry(const Aio::FdSet::Entry& entry);
+    void handleHangupEntry(const Aio::FdSet::Entry& entry);
     void handleIncoming(std::shared_ptr<Connection> connection);
     void handleResponsePacket(const std::shared_ptr<Connection>& connection, const char* buffer, size_t totalBytes);
     void handleTimeout(const std::shared_ptr<Connection>& connection);

--- a/include/pistache/os.h
+++ b/include/pistache/os.h
@@ -98,7 +98,7 @@ struct Event {
 
 class Epoll {
 public:
-    explicit Epoll(size_t max = 128);
+    Epoll();
 
     void addFd(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode = Mode::Level);
     void addFdOneShot(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode = Mode::Level);
@@ -107,8 +107,7 @@ public:
     void rearmFd(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode = Mode::Level);
 
     int poll(std::vector<Event>& events,
-             size_t maxEvents = Const::MaxEvents,
-             std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) const;
+             const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1)) const;
 
 private:
     static int toEpollEvents(const Flags<NotifyOn>& interest);

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -143,8 +143,8 @@ namespace Polling {
         , tag(_tag)
     { }
 
-    Epoll::Epoll(size_t max) {
-       epoll_fd = TRY_RET(epoll_create(max));
+    Epoll::Epoll() {
+       epoll_fd = TRY_RET(epoll_create(Const::MaxEvents));
     }
 
     void
@@ -188,12 +188,12 @@ namespace Polling {
     }
 
     int
-    Epoll::poll(std::vector<Event>& events, size_t maxEvents, std::chrono::milliseconds timeout) const {
+    Epoll::poll(std::vector<Event>& events, const std::chrono::milliseconds timeout) const {
         struct epoll_event evs[Const::MaxEvents];
 
         int ready_fds = -1;
         do {
-            ready_fds = epoll_wait(epoll_fd, evs, maxEvents, timeout.count());
+            ready_fds = epoll_wait(epoll_fd, evs, Const::MaxEvents, timeout.count());
         } while (ready_fds < 0 && errno == EINTR);
 
         for (int i = 0; i < ready_fds; ++i) {

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -135,20 +135,17 @@ public:
         if (handlers_.empty())
             throw std::runtime_error("You need to set at least one handler");
 
-        std::chrono::milliseconds timeout(-1);
-
         for (;;) {
             std::vector<Polling::Event> events;
-            int ready_fds;
-            switch (ready_fds = poller.poll(events, 1024, timeout)) {
+            int ready_fds = poller.poll(events);
+
+            switch (ready_fds) {
                 case -1: break;
                 case 0: break;
                 default:
                     if (shutdown_) return;
 
                     handleFds(std::move(events));
-
-                    timeout = std::chrono::milliseconds(-1);
             }
         }
     }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -258,8 +258,8 @@ Listener::run() {
 
     for (;;) {
         std::vector<Polling::Event> events;
+        int ready_fds = poller.poll(events);
 
-        int ready_fds = poller.poll(events, 128, std::chrono::milliseconds(-1));
         if (ready_fds == -1) {
             if (errno == EINTR && g_listen_fd == -1) return;
             throw Error::system("Polling");


### PR DESCRIPTION
In this PR have made refactoring to improve API and code structure:
1) I've removed several magic numbers: `size` value that is passed to `epoll_create` is a hint and used for backward compatibility (see [here](http://man7.org/linux/man-pages/man2/epoll_create.2.html)).
2) I've changed `timeout` default value in `Epoll::poll` to wait infinity: this behavior is closer to how it's used in Pistache.
3) Pass `Const::MaxEvents` value to `maxevents` of `epoll_wait` function that is equal to `events` array size otherwise we should have additional check that the real size of array is greater or equal to `maxevents` (to prevent out of bound array access).
4) I've improved `Transport::onReady`, extract several methods because a lot of nested `if`'s look cumbersome + added assert's. 