### PR TITLE
Fixes Segment fault in Pistache::DynamicStreamBuf::overflow #298

### DIFF
--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -106,7 +106,7 @@ DynamicStreamBuf::overflow(DynamicStreamBuf::int_type ch) {
     if (!traits_type::eq_int_type(ch, traits_type::eof())) {
         const auto size = data_.size();
         if (size < maxSize_) {
-            reserve(size * 2);
+            reserve(std::max(size, 1LU) * 2);
             *pptr() = ch;
             pbump(1);
             return traits_type::not_eof(ch);


### PR DESCRIPTION
This patches the issue described in #298 (Segment fault in Pistache::DynamicStreamBuf::overflow).