### PR TITLE
Remove std::regex in server code

### DIFF
--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <regex>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -122,12 +121,6 @@ private:
     std::shared_ptr<SegmentTreeNode> splat_;
     std::shared_ptr<Route> route_;
 
-    /**
-     * Common web servers (nginx, httpd, IIS) collapse multiple
-     * forward slashes to a single one. This regex is used to
-     * obtain the same result.
-     */
-    static std::regex multiple_slash;
 
     static SegmentType getSegmentType(const std::string_view& fragment);
 

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -59,9 +59,6 @@ Request::splat() const {
     return splats_;
 }
 
-std::regex SegmentTreeNode::multiple_slash = std::regex("//+",
-    std::regex_constants::optimize);
-
 SegmentTreeNode::SegmentTreeNode(): resource_ref_(),
         fixed_(), param_(), optional_(), splat_(nullptr), route_(nullptr) {
     std::shared_ptr<char> ptr(new char[0], std::default_delete<char[]>());
@@ -98,8 +95,14 @@ SegmentTreeNode::getSegmentType(const std::string_view& fragment) {
 }
 
 std::string SegmentTreeNode::sanitizeResource(const std::string& path) {
-    const auto& dup = std::regex_replace(path,
-        SegmentTreeNode::multiple_slash, std::string("/"));
+    std::string dup;
+    dup.reserve(path.size());
+    for (size_t i = 0; i < path.size(); ++i) {
+        if (path[i] == '/' && i != 0 && path[i-1] == '/') {
+          continue;
+        }
+        dup.push_back(path[i]);
+    }
     if (dup[dup.length() - 1] == '/') {
         return dup.substr(1, dup.length() - 2);
     }


### PR DESCRIPTION
std::regex is not implemented until GCC 4.9. By replacing it by
a handcrafted code can make pistache server compatible with GCC 4.8.


Fix #507