### PR TITLE
Kip debianization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ For those that prefer IRC over Slack, the rag-tag crew of maintainers idle in `#
 # Precompiled packages
 
 ## Ubuntu PPA (Stable)
-If you would like to use [stable](https://launchpad.net/%7Ekip/+archive/ubuntu/pistache-stable) packages, run the following:
+If you would like to use [stable](https://launchpad.net/%7Ekip/+archive/ubuntu/pistache) packages, run the following:
 
 ```console
-$ sudo add-apt-repository ppa:kip/pistache-stable
+$ sudo add-apt-repository ppa:kip/pistache
 $ sudo apt update
 $ sudo apt install libpistache-dev
 ```

--- a/quickstart.html
+++ b/quickstart.html
@@ -127,10 +127,10 @@ and asynchronous API.</p>
 
 A request for official Debian sponsorship of our package was submitted on 23 April, 2019. You can follow its progress <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=927839">here</a>. In the mean time you can try our Ubuntu packages.
 
-<p>To use our Ubuntu PPA for <a href="https://launchpad.net/%7Ekip/+archive/ubuntu/pistache-stable">stable</a> packages, run the following:</p>
+<p>To use our Ubuntu PPA for <a href="https://launchpad.net/%7Ekip/+archive/ubuntu/pistache">stable</a> packages, run the following:</p>
 
 <p><code>
-$ sudo add-apt-repository ppa:kip/pistache-stable<br />
+$ sudo add-apt-repository ppa:kip/pistache<br />
 $ sudo apt update<br />
 $ sudo apt install libpistache-dev<br />
 </code></p>


### PR DESCRIPTION
Fixed stable PPA name. It was wrong in the README.md and on the website.