### PR TITLE
Add error handling in cases of writing to an invalid file descriptor

### DIFF
--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -269,6 +269,11 @@ Transport::asyncWriteImpl(Fd fd)
                     wq.push_front(WriteEntry(std::move(deferred), bufferHolder, flags));
                     reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
                 }
+                else if (errno == EBADF) {
+                    wq.pop_front();
+                    toWrite.erase(fd);
+                    stop = true;
+                }
                 else {
                     cleanUp();
                     deferred.reject(Pistache::Error::system("Could not write data"));

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -269,6 +269,9 @@ Transport::asyncWriteImpl(Fd fd)
                     wq.push_front(WriteEntry(std::move(deferred), bufferHolder, flags));
                     reactor()->modifyFd(key(), fd, NotifyOn::Read | NotifyOn::Write, Polling::Mode::Edge);
                 }
+                // EBADF can happen when the HTTP parser, in the case of
+                // an error, closes fd before the entire request is processed.
+                // https://github.com/oktal/pistache/issues/501
                 else if (errno == EBADF) {
                     wq.pop_front();
                     toWrite.erase(fd);


### PR DESCRIPTION
Related to recent unit test intermittent failures.

Handles a condition where the file descriptor for a connection is closed
before all processing is done, leading to an error. This is usually the
result of multiple exceptions being thrown by the HTTP parser without a
connection being set to `Keep-Alive`.

In the error case the HTTP parser code closes the file descriptor but there are multiple replies in flight internally. Previously when the `send()` call failed, Pistache would still try to modify the file descriptor which lead to an error from the `epoll` code. This change modifies the cleanup code when a bad file descriptor is detected during send to skip trying to modify the file descriptor.

Closes #501 (same error message) and makes the unit tests reliable again.