### PR TITLE
remove broken Tcp::Options::InstallSignalHandler

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ pistache_example(http_server)
 pistache_example(http_client)
 pistache_example(rest_server)
 pistache_example(custom_header)
+pistache_example(http_server_shutdown)
 
 set(RAPIDJSON_ROOT_DIR PATH "${PROJECT_SOURCE_DIR}/third-party/rapidjson")
 

--- a/examples/hello_server.cc
+++ b/examples/hello_server.cc
@@ -29,6 +29,4 @@ int main() {
     server.init(opts);
     server.setHandler(Http::make_handler<HelloHandler>());
     server.serve();
-
-    server.shutdown();
 }

--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -171,12 +171,8 @@ int main(int argc, char *argv[]) {
     auto server = std::make_shared<Http::Endpoint>(addr);
 
     auto opts = Http::Endpoint::options()
-        .threads(thr)
-        .flags(Tcp::Options::InstallSignalHandler);
+        .threads(thr);
     server->init(opts);
     server->setHandler(Http::make_handler<MyHandler>());
     server->serve();
-
-    std::cout << "Shutdowning server" << std::endl;
-    server->shutdown();
 }

--- a/examples/http_server_shutdown.cc
+++ b/examples/http_server_shutdown.cc
@@ -19,6 +19,7 @@ int main() {
     if (sigemptyset(&signals) != 0
             || sigaddset(&signals, SIGTERM) != 0
             || sigaddset(&signals, SIGINT) != 0
+            || sigaddset(&signals, SIGHUP) != 0
             || pthread_sigmask(SIG_BLOCK, &signals, nullptr) != 0) {
         perror("install signal handler failed");
         return 1;

--- a/examples/http_server_shutdown.cc
+++ b/examples/http_server_shutdown.cc
@@ -1,0 +1,48 @@
+#include "pistache/endpoint.h"
+#include <signal.h>
+
+using namespace Pistache;
+
+class HelloHandler : public Http::Handler {
+public:
+
+    HTTP_PROTOTYPE(HelloHandler)
+
+    void onRequest(const Http::Request& request, Http::ResponseWriter response) override{
+        UNUSED(request);
+        response.send(Pistache::Http::Code::Ok, "Hello World\n");
+    }
+};
+
+int main() {
+    sigset_t signals;
+    if (sigemptyset(&signals) != 0
+            || sigaddset(&signals, SIGTERM) != 0
+            || sigaddset(&signals, SIGINT) != 0
+            || pthread_sigmask(SIG_BLOCK, &signals, nullptr) != 0) {
+        perror("install signal handler failed");
+        return 1;
+    }
+
+    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(9080));
+    auto opts = Pistache::Http::Endpoint::options()
+        .threads(1);
+
+    Http::Endpoint server(addr);
+    server.init(opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+
+    int signal = 0;
+    int status = sigwait(&signals, &signal);
+    if (status == 0)
+    {
+        std::cout << "received signal " << signal << std::endl;
+    }
+    else
+    {
+        std::cerr << "sigwait returns " << status << std::endl;
+    }
+
+    server.shutdown();
+}

--- a/examples/rest_description.cc
+++ b/examples/rest_description.cc
@@ -30,8 +30,7 @@ public:
 
     void init(size_t thr = 2) {
         auto opts = Http::Endpoint::options()
-            .threads(thr)
-            .flags(Tcp::Options::InstallSignalHandler);
+            .threads(thr);
         httpEndpoint->init(opts);
         createDescription();
     }
@@ -49,10 +48,6 @@ public:
 
         httpEndpoint->setHandler(router.handler());
         httpEndpoint->serve();
-    }
-
-    void shutdown() {
-        httpEndpoint->shutdown();
     }
 
 private:
@@ -157,6 +152,4 @@ int main(int argc, char *argv[]) {
 
     banker.init(thr);
     banker.start();
-
-    banker.shutdown();
 }

--- a/examples/rest_server.cc
+++ b/examples/rest_server.cc
@@ -39,8 +39,7 @@ public:
 
     void init(size_t thr = 2) {
         auto opts = Http::Endpoint::options()
-            .threads(thr)
-            .flags(Tcp::Options::InstallSignalHandler);
+            .threads(thr);
         httpEndpoint->init(opts);
         setupRoutes();
     }
@@ -48,10 +47,6 @@ public:
     void start() {
         httpEndpoint->setHandler(router.handler());
         httpEndpoint->serve();
-    }
-
-    void shutdown() {
-        httpEndpoint->shutdown();
     }
 
 private:
@@ -170,6 +165,4 @@ int main(int argc, char *argv[]) {
 
     stats.init(thr);
     stats.start();
-
-    stats.shutdown();
 }

--- a/include/pistache/tcp.h
+++ b/include/pistache/tcp.h
@@ -25,9 +25,7 @@ enum class Options : uint64_t {
     Linger               = NoDelay << 1,
     FastOpen             = Linger << 1,
     QuickAck             = FastOpen << 1,
-    ReuseAddr            = QuickAck << 1,
-    ReverseLookup        = ReuseAddr << 1,
-    InstallSignalHandler = ReverseLookup << 1
+    ReuseAddr            = QuickAck << 1
 };
 
 DECLARE_FLAGS_OPERATORS(Options)

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -191,10 +191,7 @@ namespace Polling {
     Epoll::poll(std::vector<Event>& events, const std::chrono::milliseconds timeout) const {
         struct epoll_event evs[Const::MaxEvents];
 
-        int ready_fds = -1;
-        do {
-            ready_fds = epoll_wait(epoll_fd, evs, Const::MaxEvents, timeout.count());
-        } while (ready_fds < 0 && errno == EINTR);
+        int ready_fds = epoll_wait(epoll_fd, evs, Const::MaxEvents, timeout.count());
 
         for (int i = 0; i < ready_fds; ++i) {
             const struct epoll_event *ev = evs + i;

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -37,21 +37,6 @@
 namespace Pistache {
 namespace Tcp {
 
-namespace {
-    volatile sig_atomic_t g_listen_fd = -1;
-
-    void closeListener() {
-        if (g_listen_fd != -1) {
-            ::close(g_listen_fd);
-            g_listen_fd = -1;
-        }
-    }
-
-    void handle_sigint(int) {
-        closeListener();
-    }
-}
-
 void setSocketOptions(Fd fd, Flags<Options> options) {
     if (options.hasFlag(Options::ReuseAddr)) {
         int one = 1;
@@ -129,13 +114,6 @@ Listener::init(
     options_ = options;
     backlog_ = backlog;
     useSSL_ = false;
-
-    if (options_.hasFlag(Options::InstallSignalHandler)) {
-        if (signal(SIGINT, handle_sigint) == SIG_ERR) {
-            throw std::runtime_error("Could not install signal handler");
-        }
-    }
-
     workers_ = workers;
 
 }
@@ -213,7 +191,6 @@ Listener::bind(const Address& address) {
     make_non_blocking(fd);
     poller.addFd(fd, Polling::NotifyOn::Read, Polling::Tag(fd));
     listen_fd = fd;
-    g_listen_fd = fd;
 
     auto transport = std::make_shared<Transport>(handler_);
 
@@ -261,7 +238,6 @@ Listener::run() {
         int ready_fds = poller.poll(events);
 
         if (ready_fds == -1) {
-            if (errno == EINTR && g_listen_fd == -1) return;
             throw Error::system("Polling");
         }
         for (const auto& event: events) {

--- a/tests/cookie_test_3.cc
+++ b/tests/cookie_test_3.cc
@@ -28,7 +28,7 @@ TEST(http_client_test, one_client_with_one_request_with_onecookie) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<CookieHandler>());
@@ -69,7 +69,7 @@ TEST(http_client_test, one_client_with_one_request_with_several_cookies) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<CookieHandler>());

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -65,7 +65,7 @@ TEST(http_client_test, one_client_with_one_request)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -101,7 +101,7 @@ TEST(http_client_test, one_client_with_multiple_requests)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -145,7 +145,7 @@ TEST(http_client_test, multiple_clients_with_one_request) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -211,7 +211,7 @@ TEST(http_client_test, timeout_reject)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<DelayHandler>());
@@ -249,7 +249,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_one_connection_per_
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -295,7 +295,7 @@ TEST(http_client_test, one_client_with_multiple_requests_and_two_connections_per
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandler>());
@@ -341,7 +341,7 @@ TEST(http_client_test, test_client_timeout)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags).threads(4);
     server.init(server_opts);
     server.setHandler(Http::make_handler<FastEvenPagesHandler>());
@@ -405,7 +405,7 @@ TEST(http_client_test, client_sends_query)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<QueryBounceHandler>());

--- a/tests/http_server_test.cc
+++ b/tests/http_server_test.cc
@@ -130,7 +130,7 @@ TEST(http_server_test, client_disconnection_on_timeout_from_single_threaded_serv
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     const int ONE_SECOND_TIMEOUT = 1;
@@ -153,7 +153,7 @@ TEST(http_server_test, client_multiple_requests_disconnection_on_timeout_from_si
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
 
@@ -177,7 +177,7 @@ TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server) {
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags).threads(3);
     server.init(server_opts);
     server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
@@ -214,7 +214,7 @@ TEST(http_server_test, multiple_client_with_different_requests_to_multithreaded_
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags).threads(4);
     server.init(server_opts);
     const int SIX_SECONDS_DELAY = 6;
@@ -273,7 +273,7 @@ TEST(http_server_test, server_with_static_file)
     const Pistache::Address address("localhost", Pistache::Port(0));
 
     Http::Endpoint server(address);
-    auto flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto flags = Tcp::Options::ReuseAddr;
     auto server_opts = Http::Endpoint::options().flags(flags);
     server.init(server_opts);
     server.setHandler(Http::make_handler<FileHandler>(fileName));

--- a/tests/https_server_test.cc
+++ b/tests/https_server_test.cc
@@ -28,7 +28,7 @@ struct HelloHandler : public Http::Handler {
 
 TEST(http_client_test, basic_tls_request) {
     Http::Endpoint server(ADDRESS "1");
-    auto           flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto           flags = Tcp::Options::ReuseAddr;
     auto           server_opts = Http::Endpoint::options().flags(flags);
 
     server.init(server_opts);
@@ -65,7 +65,7 @@ TEST(http_client_test, basic_tls_request) {
 
 TEST(http_client_test, basic_tls_request_with_auth) {
     Http::Endpoint server(ADDRESS "2");
-    auto           flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto           flags = Tcp::Options::ReuseAddr;
     auto           server_opts = Http::Endpoint::options().flags(flags);
 
     server.init(server_opts);
@@ -106,7 +106,7 @@ TEST(http_client_test, basic_tls_request_with_auth) {
 
 TEST(http_client_test, basic_tls_request_with_auth_no_client_cert) {
     Http::Endpoint server(ADDRESS "3");
-    auto           flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto           flags = Tcp::Options::ReuseAddr;
     auto           server_opts = Http::Endpoint::options().flags(flags);
 
     server.init(server_opts);
@@ -144,7 +144,7 @@ TEST(http_client_test, basic_tls_request_with_auth_no_client_cert) {
 
 TEST(http_client_test, basic_tls_request_with_auth_client_cert_not_signed) {
     Http::Endpoint server(ADDRESS "4");
-    auto           flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto           flags = Tcp::Options::ReuseAddr;
     auto           server_opts = Http::Endpoint::options().flags(flags);
 
     server.init(server_opts);
@@ -195,7 +195,7 @@ static int verify_callback(int verify, void *ctx)
 
 TEST(http_client_test, basic_tls_request_with_auth_with_cb) {
     Http::Endpoint server(ADDRESS "5");
-    auto           flags = Tcp::Options::InstallSignalHandler | Tcp::Options::ReuseAddr;
+    auto           flags = Tcp::Options::ReuseAddr;
     auto           server_opts = Http::Endpoint::options().flags(flags);
 
     server.init(server_opts);

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -23,8 +23,7 @@ public:
 
     void init(size_t thr = 2) {
         auto opts = Http::Endpoint::options()
-                .threads(thr)
-                .flags(Tcp::Options::InstallSignalHandler);
+                .threads(thr);
         httpEndpoint->init(opts);
         setupRoutes();
     }


### PR DESCRIPTION
(see discussion in #221)
Also remove unreachable shutdown() from examples and add
http_server_shutdown example with signal handling (thanks to 1Hyena).
