### PR TITLE
Timeout use-after-free error

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -216,6 +216,8 @@ public:
         other.timerFd = -1;
     }
 
+    ~Timeout() { disarm(); }
+
     Timeout& operator=(Timeout&& other) {
         handler = other.handler;
         transport = other.transport;


### PR DESCRIPTION
Found this when I was hunting for something else. Adding a destructor with disarm() to Timeout class to avoid a use-after-free error. To replicate error, run run_http_server example, curl to localhost:9080/timeout, and ctrl-c immediately.