### PR TITLE
Recursive rejects

### DIFF
--- a/include/pistache/async.h
+++ b/include/pistache/async.h
@@ -288,16 +288,19 @@ namespace Async {
 
             void resolve(const std::shared_ptr<Core>& core) override {
                 if (resolveCount_ >= 1)
-                    throw Error("Resolve must not be called more than once");
+                  return; //TODO is this the right thing?
+                    //throw Error("Resolve must not be called more than once");
 
-                doResolve(coreCast(core));
                 ++resolveCount_;
+                doResolve(coreCast(core));
             }
 
             void reject(const std::shared_ptr<Core>& core) override {
                 if (rejectCount_ >= 1)
-                    throw Error("Reject must not be called more than once");
+                  return; //TODO is this the right thing?
+                    //throw Error("Reject must not be called more than once");
 
+                ++rejectCount_;
                 try {
                     doReject(coreCast(core));
                 } catch (const InternalRethrow& e) {
@@ -308,7 +311,6 @@ namespace Async {
                     }
                 }
 
-                ++rejectCount_;
             }
 
             std::shared_ptr<CoreT<T>> coreCast(const std::shared_ptr<Core>& core) const {


### PR DESCRIPTION
This is trying to solve the same problem as #337 
- Added the test from that issue
- Changed the chain handling behaviour to immediately increment the reject counter, and to just return if an attempt is made to reject the promise already (as it's already been rejected).

I'm not 100% sure that this is the right approach, but it works for my workload (hundreds of short and very long (>4 minute) requests, with clients disconnecting mid-request. It also passes all the unit tests.

I just think this needs a code review from someone who understands the promise system more deeply than I do.