### PR TITLE
Adding hostname resolution to peer

### DIFF
--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -41,7 +41,7 @@ public:
     ~Peer();
     
     const Address& address() const;
-    const std::string& hostname() const;
+    const std::string& hostname();
 
     void associateFd(Fd fd);
     Fd fd() const;
@@ -69,7 +69,7 @@ private:
     void *ssl_;
 };
 
-std::ostream& operator<<(std::ostream& os, const Peer& peer);
+std::ostream& operator<<(std::ostream& os, Peer& peer);
 
 } // namespace Tcp
 } // namespace Pistache

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -1,6 +1,6 @@
-/* 
+/*
    Mathieu Stefani, 07 février 2016
-   
+
    Example of a REST endpoint with routing
 */
 
@@ -45,6 +45,7 @@ private:
     void setupRoutes() {
         using namespace Rest;
         Routes::Get(router, "/read/function1", Routes::bind(&StatsEndpoint::doAuth, this));
+        Routes::Get(router, "/read/hostname", Routes::bind(&StatsEndpoint::doResolveClient, this));
     }
 
     void doAuth(const Rest::Request& /*request*/, Http::ResponseWriter response) {
@@ -52,6 +53,10 @@ private:
             writer.send(Http::Code::Ok, "1");
         }, std::move(response));
         worker.detach();
+    }
+
+    void doResolveClient(const Rest::Request& /*request*/, Http::ResponseWriter response) {
+        response.send(Http::Code::Ok, response.peer()->hostname());
     }
 
     std::shared_ptr<Http::Endpoint> httpEndpoint;
@@ -78,6 +83,9 @@ TEST(rest_server_test, basic_test) {
     ASSERT_EQ(res->status, 200);
     ASSERT_EQ(res->body, "1");
 
+    res = client.Get("/read/hostname");
+    ASSERT_EQ(res->status, 200);
+    ASSERT_EQ(res->body, "localhost");
     stats.shutdown();
 }
 


### PR DESCRIPTION
Adds automatic peer hostname resolution, as `Peer::hostname_` is not currently populated by any means.

This removes the const-ness of ::hostname() and the ostream printer. I thought about adding a '::resolveHostname()' method, but if someone asks for the hostname, resolution will need to happen regardless.

Added a unit test, but it may fail as it assumes that the resolution sequence ("localhost" -> ip -> hostname), hostname = "localhost".