### PR TITLE
Set Thread name for running HTTP server threads

### DIFF
--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -19,7 +19,7 @@ public:
         friend class Endpoint;
 
         Options& threads(int val);
-        Options& threadsName(const char* val);
+        Options& threadsName(std::string val);
         Options& flags(Flags<Tcp::Options> flags);
         Options& backlog(int val);
         Options& maxRequestSize(size_t val);
@@ -30,7 +30,7 @@ public:
 
     private:
         int threads_;
-        char threadsName_[16];
+        std::string threadsName_;
         Flags<Tcp::Options> flags_;
         int backlog_;
         size_t maxRequestSize_;

--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -19,7 +19,7 @@ public:
         friend class Endpoint;
 
         Options& threads(int val);
-        Options& threadsName(std::string val);
+        Options& threadsName(const std::string& val);
         Options& flags(Flags<Tcp::Options> flags);
         Options& backlog(int val);
         Options& maxRequestSize(size_t val);

--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -19,6 +19,7 @@ public:
         friend class Endpoint;
 
         Options& threads(int val);
+        Options& threadsName(const char* val);
         Options& flags(Flags<Tcp::Options> flags);
         Options& backlog(int val);
         Options& maxRequestSize(size_t val);
@@ -29,6 +30,7 @@ public:
 
     private:
         int threads_;
+        char threadsName_[16];
         Flags<Tcp::Options> flags_;
         int backlog_;
         size_t maxRequestSize_;

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -52,7 +52,7 @@ public:
     void init(
             size_t workers,
             Flags<Options> options = Options::None,
-            std::string workersName = "",
+            const std::string& workersName = "",
             int backlog = Const::MaxBacklog);
     void setHandler(const std::shared_ptr<Handler>& handler);
 

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -52,7 +52,7 @@ public:
     void init(
             size_t workers,
             Flags<Options> options = Options::None,
-            const char * workersName = "",
+            std::string workersName = "",
             int backlog = Const::MaxBacklog);
     void setHandler(const std::shared_ptr<Handler>& handler);
 
@@ -66,7 +66,7 @@ public:
     void runThreaded();
 
     void shutdown();
- 
+
     Async::Promise<Load> requestLoad(const Load& old);
 
     Options options() const;
@@ -88,7 +88,7 @@ private:
     std::thread acceptThread;
 
     size_t workers_;
-    char   workersName_[16];
+    std::string workersName_;
     std::shared_ptr<Handler> handler_;
 
     Aio::Reactor reactor_;

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -52,6 +52,7 @@ public:
     void init(
             size_t workers,
             Flags<Options> options = Options::None,
+            const char * workersName = "",
             int backlog = Const::MaxBacklog);
     void setHandler(const std::shared_ptr<Handler>& handler);
 
@@ -65,7 +66,7 @@ public:
     void runThreaded();
 
     void shutdown();
-
+ 
     Async::Promise<Load> requestLoad(const Load& old);
 
     Options options() const;
@@ -87,6 +88,7 @@ private:
     std::thread acceptThread;
 
     size_t workers_;
+    char   workersName_[16];
     std::shared_ptr<Handler> handler_;
 
     Aio::Reactor reactor_;

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -176,9 +176,10 @@ public:
 
 class AsyncContext : public ExecutionContext {
 public:
-    explicit AsyncContext(size_t threads)
+    explicit AsyncContext(size_t threads,const char* threadsName = "")
         : threads_(threads)
-    { }
+
+    { strcpy(threadsName_,threadsName);}
 
     virtual ~AsyncContext() {}
 
@@ -188,6 +189,7 @@ public:
 
 private:
     size_t threads_;
+    char threadsName_[16];
 };
 
 class Handler : public Prototype<Handler> {

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -176,7 +176,7 @@ public:
 
 class AsyncContext : public ExecutionContext {
 public:
-    explicit AsyncContext(size_t threads, std::string threadsName = "")
+    explicit AsyncContext(size_t threads,const std::string& threadsName = "")
         : threads_(threads)
 
     {

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -176,10 +176,12 @@ public:
 
 class AsyncContext : public ExecutionContext {
 public:
-    explicit AsyncContext(size_t threads,const char* threadsName = "")
+    explicit AsyncContext(size_t threads, std::string threadsName = "")
         : threads_(threads)
 
-    { strcpy(threadsName_,threadsName);}
+    {
+        threadsName_ = threadsName;
+    }
 
     virtual ~AsyncContext() {}
 
@@ -189,7 +191,7 @@ public:
 
 private:
     size_t threads_;
-    char threadsName_[16];
+    std::string threadsName_;
 };
 
 class Handler : public Prototype<Handler> {

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -176,7 +176,7 @@ public:
 
 class AsyncContext : public ExecutionContext {
 public:
-    explicit AsyncContext(size_t threads,const std::string& threadsName = "")
+    explicit AsyncContext(size_t threads, const std::string& threadsName = "")
         : threads_(threads)
 
     {

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -611,9 +611,7 @@ AsyncContext::makeImpl(Reactor* reactor) const {
 
 AsyncContext
 AsyncContext::singleThreaded() {
-    char threadNameSingle[2];
-    threadNameSingle[1]='\0';
-    return AsyncContext(1, threadNameSingle);
+    return AsyncContext(1);
 }
 
 } // namespace Aio

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -334,7 +334,7 @@ public:
 
     static constexpr uint32_t KeyMarker = 0xBADB0B;
 
-    AsyncImpl(Reactor* reactor, size_t threads,const std::string& threadsName)
+    AsyncImpl(Reactor* reactor, size_t threads, const std::string& threadsName)
         : Reactor::Impl(reactor) {
 
         for (size_t i = 0; i < threads; ++i) {
@@ -454,7 +454,7 @@ private:
 
     struct Worker {
 
-        explicit Worker(Reactor* reactor,const std::string& threadsName) {
+        explicit Worker(Reactor* reactor, const std::string& threadsName) {
             threadsName_ = threadsName;
             sync.reset(new SyncImpl(reactor));
         }

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -334,7 +334,7 @@ public:
 
     static constexpr uint32_t KeyMarker = 0xBADB0B;
 
-    AsyncImpl(Reactor* reactor, size_t threads, std::string threadsName)
+    AsyncImpl(Reactor* reactor, size_t threads,const std::string& threadsName)
         : Reactor::Impl(reactor) {
 
         for (size_t i = 0; i < threads; ++i) {
@@ -454,7 +454,7 @@ private:
 
     struct Worker {
 
-        explicit Worker(Reactor* reactor, std::string threadsName) {
+        explicit Worker(Reactor* reactor,const std::string& threadsName) {
             threadsName_ = threadsName;
             sync.reset(new SyncImpl(reactor));
         }

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,7 +14,7 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
-    , threadsName_("")
+    , threadsName_()
     , flags_()
     , backlog_(Const::MaxBacklog)
     , maxRequestSize_(Const::DefaultMaxRequestSize)

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,6 +14,7 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
+    , threadsName_("")
     , flags_()
     , backlog_(Const::MaxBacklog)
     , maxRequestSize_(Const::DefaultMaxRequestSize)
@@ -23,6 +24,13 @@ Endpoint::Options::Options()
 Endpoint::Options&
 Endpoint::Options::threads(int val) {
     threads_ = val;
+    return *this;
+}
+
+Endpoint::Options&
+Endpoint::Options::threadsName(const char* val) {
+    strncpy(threadsName_, val, 15);
+    threadsName_[15] = '\0';
     return *this;
 }
 
@@ -64,7 +72,7 @@ Endpoint::Endpoint(const Address& addr)
 
 void
 Endpoint::init(const Endpoint::Options& options) {
-    listener.init(options.threads_, options.flags_);
+    listener.init(options.threads_,  options.flags_, options.threadsName_);
     ArrayStreamBuf<char>::maxSize = options.maxRequestSize_;
     DynamicStreamBuf::maxSize = options.maxResponseSize_;
 }

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -14,7 +14,6 @@ namespace Http {
 
 Endpoint::Options::Options()
     : threads_(1)
-    , threadsName_()
     , flags_()
     , backlog_(Const::MaxBacklog)
     , maxRequestSize_(Const::DefaultMaxRequestSize)
@@ -28,9 +27,8 @@ Endpoint::Options::threads(int val) {
 }
 
 Endpoint::Options&
-Endpoint::Options::threadsName(const char* val) {
-    strncpy(threadsName_, val, 15);
-    threadsName_[15] = '\0';
+Endpoint::Options::threadsName(std::string val) {
+    threadsName_ = val;
     return *this;
 }
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -70,7 +70,7 @@ Endpoint::Endpoint(const Address& addr)
 
 void
 Endpoint::init(const Endpoint::Options& options) {
-    listener.init(options.threads_,  options.flags_, options.threadsName_);
+    listener.init(options.threads_, options.flags_, options.threadsName_);
     ArrayStreamBuf<char>::maxSize = options.maxRequestSize_;
     DynamicStreamBuf::maxSize = options.maxResponseSize_;
 }

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -27,7 +27,7 @@ Endpoint::Options::threads(int val) {
 }
 
 Endpoint::Options&
-Endpoint::Options::threadsName(std::string val) {
+Endpoint::Options::threadsName(const std::string& val) {
     threadsName_ = val;
     return *this;
 }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -69,6 +69,7 @@ Listener::Listener()
     , poller()
     , options_()
     , workers_(Const::DefaultWorkers)
+    , workersName_()
     , reactor_()
     , transportKey()
     , useSSL_(false)
@@ -82,6 +83,7 @@ Listener::Listener(const Address& address)
     , poller()
     , options_()
     , workers_(Const::DefaultWorkers)
+    , workersName_()
     , reactor_()
     , transportKey()
     , useSSL_(false)
@@ -105,7 +107,9 @@ Listener::~Listener() {
 void
 Listener::init(
     size_t workers,
-    Flags<Options> options, int backlog)
+    Flags<Options> options,
+    const char * workersName,
+    int backlog)
 {
     if (workers > hardware_concurrency()) {
         // Log::warning() << "More workers than available cores"
@@ -115,6 +119,7 @@ Listener::init(
     backlog_ = backlog;
     useSSL_ = false;
     workers_ = workers;
+    strcpy(workersName_, workersName);
 
 }
 
@@ -194,7 +199,7 @@ Listener::bind(const Address& address) {
 
     auto transport = std::make_shared<Transport>(handler_);
 
-    reactor_.init(Aio::AsyncContext(workers_));
+    reactor_.init(Aio::AsyncContext(workers_, workersName_));
     transportKey = reactor_.addHandler(transport);
 }
 

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -108,7 +108,7 @@ void
 Listener::init(
     size_t workers,
     Flags<Options> options,
-    const char * workersName,
+    std::string workersName,
     int backlog)
 {
     if (workers > hardware_concurrency()) {
@@ -119,7 +119,7 @@ Listener::init(
     backlog_ = backlog;
     useSSL_ = false;
     workers_ = workers;
-    strcpy(workersName_, workersName);
+    workersName_ = workersName;
 
 }
 

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -108,7 +108,7 @@ void
 Listener::init(
     size_t workers,
     Flags<Options> options,
-    std::string workersName,
+    const std::string& workersName,
     int backlog)
 {
     if (workers > hardware_concurrency()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ pistache_test(string_view_test)
 pistache_test(mailbox_test)
 pistache_test(stream_test)
 pistache_test(reactor_test)
+pistache_test(threadname_test)
 
 if (PISTACHE_USE_SSL)
 

--- a/tests/threadname_test.cc
+++ b/tests/threadname_test.cc
@@ -1,30 +1,197 @@
-#include "gtest/gtest.h"
+#include <pistache/async.h>
 #include <pistache/http.h>
+#include <pistache/client.h>
 #include <pistache/endpoint.h>
+#include <pistache/common.h>
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <future>
+#include <fstream>
+#include <string>
 
 using namespace Pistache;
 
-void setThreadNameTest(const std::string pThreadName)
-{
-    std::shared_ptr<Http::Endpoint> mHttpEndpoint_;
-    Address addr(Ipv4::any(), Pistache::Port(0));
-    mHttpEndpoint_ = std::make_shared<Http::Endpoint>(addr);
+struct HelloHandlerWithDelay : public Http::Handler {
+    HTTP_PROTOTYPE(HelloHandlerWithDelay)
 
-    auto test_options = Http::Endpoint::options()
-          .threads(2)
-          .threadsName(pThreadName);
-    mHttpEndpoint_->init(test_options);
+    explicit HelloHandlerWithDelay(int delay = 0) : delay_(delay)
+    { }
+
+    void onRequest(const Http::Request& /*request*/, Http::ResponseWriter writer) override
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(delay_));
+        writer.send(Http::Code::Ok, "Hello, World!");
+    }
+
+    int delay_;
+};
+
+
+int clientLogicFunc(int response_size,
+                    const std::string& server_page, 
+                    int wait_seconds)
+{
+    Http::Client client;
+    client.init();
+
+    std::vector<Async::Promise<Http::Response>> responses; 
+    auto rb = client.get(server_page);
+    int resolver_counter = 0;
+    int reject_counter = 0;
+    for (int i = 0; i < response_size; ++i)
+    {
+        auto response = rb.send();
+        response.then([&resolver_counter](Http::Response resp)
+                      {
+                          std::cout << "Response code is " << resp.code() << std::endl;
+                          if (resp.code() == Http::Code::Ok)
+                          {
+                              ++resolver_counter;
+                          }
+                      },
+                      [&reject_counter](std::exception_ptr exc)
+                      {
+                          PrintException excPrinter;
+                          std::cout << "Reject with reason: ";
+                          excPrinter(exc);
+                          ++reject_counter;
+                      });
+        responses.push_back(std::move(response));
+    }
+
+    auto sync = Async::whenAll(responses.begin(), responses.end());
+    Async::Barrier<std::vector<Http::Response>> barrier(sync);
+    barrier.wait_for(std::chrono::seconds(wait_seconds));
+    
+    client.shutdown();
+
+    std::cout << "resolves: " << resolver_counter
+              << ", rejects: " << reject_counter
+              << "\n";
+
+    return resolver_counter;
 }
 
-TEST(set_threadname_test, thread_naming_test)
-{
-    const std::string null_str = "";
-    const std::string single_char = "a";
-    const std::string max_length = "0123456789abcdef";
-    const std::string exceed_length = "0123456789abcdefghi";
+TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server_threadName_null_str) {
+    const Pistache::Address address("localhost", Pistache::Port(0));
 
-    EXPECT_NO_THROW(setThreadNameTest(null_str));
-    EXPECT_NO_THROW(setThreadNameTest(single_char));
-    EXPECT_NO_THROW(setThreadNameTest(max_length));
-    EXPECT_NO_THROW(setThreadNameTest(exceed_length));
+    const std::string threadName_null_str = "";
+
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(2).threadsName(threadName_null_str);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
+    server.serveThreaded();
+
+    const std::string server_address = "localhost:" + server.getPort().toString();
+    std::cout << "Server address: " << server_address << "\n";
+
+    const int CLIENT_REQUEST_SIZE = 2;
+    const int SIX_SECONDS_TIMOUT = 6;
+    std::future<int> result(std::async(clientLogicFunc,
+                                        CLIENT_REQUEST_SIZE,
+                                        server_address, 
+                                        SIX_SECONDS_TIMOUT));
+
+    int res1 = result.get();
+
+    server.shutdown();
+
+    ASSERT_EQ(res1, CLIENT_REQUEST_SIZE);
+    
+}
+
+TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server_threadName_single_char) {
+    const Pistache::Address address("localhost", Pistache::Port(0));
+
+    const std::string threadName_single_char = "a";
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(2).threadsName(threadName_single_char);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
+    server.serveThreaded();
+
+    const std::string server_address = "localhost:" + server.getPort().toString();
+    std::cout << "Server address: " << server_address << "\n";
+
+    const int CLIENT_REQUEST_SIZE = 2;
+    const int SIX_SECONDS_TIMOUT = 6;
+    std::future<int> result(std::async(clientLogicFunc,
+                                        CLIENT_REQUEST_SIZE,
+                                        server_address, 
+                                        SIX_SECONDS_TIMOUT));
+
+    int res1 = result.get();
+
+    server.shutdown();
+
+    ASSERT_EQ(res1, CLIENT_REQUEST_SIZE);
+    
+}
+
+TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server_threadName_max_length) {
+    const Pistache::Address address("localhost", Pistache::Port(0));
+
+    const std::string threadName_max_length = "0123456789abcdef";
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(2).threadsName(threadName_max_length);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
+    server.serveThreaded();
+
+    const std::string server_address = "localhost:" + server.getPort().toString();
+    std::cout << "Server address: " << server_address << "\n";
+
+    const int CLIENT_REQUEST_SIZE = 2;
+    const int SIX_SECONDS_TIMOUT = 6;
+    std::future<int> result(std::async(clientLogicFunc,
+                                        CLIENT_REQUEST_SIZE,
+                                        server_address, 
+                                        SIX_SECONDS_TIMOUT));
+
+    int res1 = result.get();
+
+    server.shutdown();
+
+    ASSERT_EQ(res1, CLIENT_REQUEST_SIZE);
+    
+}
+
+TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server_threadName_exceed_length) {
+    const Pistache::Address address("localhost", Pistache::Port(0));
+
+    const std::string threadName_exceed_length = "0123456789abcdefghi";
+
+
+    Http::Endpoint server(address);
+    auto flags = Tcp::Options::ReuseAddr;
+    auto server_opts = Http::Endpoint::options().flags(flags).threads(2).threadsName(threadName_exceed_length);
+    server.init(server_opts);
+    server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
+    server.serveThreaded();
+
+    const std::string server_address = "localhost:" + server.getPort().toString();
+    std::cout << "Server address: " << server_address << "\n";
+
+    const int CLIENT_REQUEST_SIZE = 2;
+    const int SIX_SECONDS_TIMOUT = 6;
+    std::future<int> result(std::async(clientLogicFunc,
+                                        CLIENT_REQUEST_SIZE,
+                                        server_address, 
+                                        SIX_SECONDS_TIMOUT));
+
+    int res1 = result.get();
+
+    server.shutdown();
+
+    ASSERT_EQ(res1, CLIENT_REQUEST_SIZE);
+    
 }

--- a/tests/threadname_test.cc
+++ b/tests/threadname_test.cc
@@ -1,0 +1,30 @@
+#include "gtest/gtest.h"
+#include <pistache/http.h>
+#include <pistache/endpoint.h>
+
+using namespace Pistache;
+
+void setThreadNameTest(const std::string pThreadName)
+{
+    std::shared_ptr<Http::Endpoint> mHttpEndpoint_;
+    Address addr(Ipv4::any(), Pistache::Port(0));
+    mHttpEndpoint_ = std::make_shared<Http::Endpoint>(addr);
+
+    auto test_options = Http::Endpoint::options()
+          .threads(2)
+          .threadsName(pThreadName);
+    mHttpEndpoint_->init(test_options);
+}
+
+TEST(set_threadname_test, thread_naming_test)
+{
+    const std::string null_str = "";
+    const std::string single_char = "a";
+    const std::string max_length = "0123456789abcdef";
+    const std::string exceed_length = "0123456789abcdefghi";
+
+    EXPECT_NO_THROW(setThreadNameTest(null_str));
+    EXPECT_NO_THROW(setThreadNameTest(single_char));
+    EXPECT_NO_THROW(setThreadNameTest(max_length));
+    EXPECT_NO_THROW(setThreadNameTest(exceed_length));
+}


### PR DESCRIPTION
Setting the thread name on the server mode, it can be used to set a unique name for a thread, which can be useful for debugging  multi-threaded applications, if you are starting more than one server on different ports (the threads on each port cab be set by one name) .

**.threadsName("MyHTTPServer")**

Usage : 
```
std::shared_ptr<Http::Endpoint> mHttpEndpoint_;

auto opts = Http::Endpoint::options()
          .threads(3)
          .threadsName("MyHTTPServer")
      mHttpEndpoint_->init(opts);
```

