### PR TITLE
Removing Http's close of open fd

### DIFF
--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -651,13 +651,6 @@ ResponseWriter::putOnWire(const char* data, size_t len)
         OUT(writeHeaders(headers_, buf_));
         OUT(writeCookies(cookies_, buf_));
 
-
-        auto connection = headers_.tryGet<Header::Connection>();
-        auto control = ConnectionControl::Close;
-
-        if (connection)
-            control = connection->control();
-
         /* @Todo @Major:
          * Correctly handle non-keep alive requests
          * Do not put Keep-Alive if version == Http::11 and request.keepAlive == true
@@ -689,12 +682,6 @@ ResponseWriter::putOnWire(const char* data, size_t len)
                          [=](int /*l*/) {
 
                              return Async::Promise<ssize_t>( [=](Async::Deferred<ssize_t> /*deferred*/) mutable {
-
-                                 if (control == ConnectionControl::KeepAlive) return ;
-
-                                 if (fd)
-                                     close(fd);
-
                                 return ;
                              } );
                          },


### PR DESCRIPTION
Having Http close the fd on the peer without cleaning up Transport::peers means the following:

- First client connects, and gets fd X.
- Peer information is generated from this connection, and is inserted into Transport::peers<fd, Peer>
- Client request is served, and Http calls close on fd X, but doesn't clean up Transport::peers
- Second client connects, and fd X is reused.
- Transport::peers isn't updated, as it already exists.
- Now the peer associated with client 2 wrongly contains the info from client 1.

I opted to remove Http's closing of the fd, since it shouldn't be releasing resources that it doesn't own. FD closing and peers cleanup is handled by Transport::handlePeerDisconnection().

If there are clients out there that rely on the server disconnecting the TCP session after the full request has been served, this change could cause those clients to hang indefinitely. I'm not sure how many clients out there are like that, though, as the payload size is explicitly sent to them.

All of this is because Peer::hostname() will have stale information if many different servers connect serially with shortlived requests.