### PR TITLE
CMake: fix RapidJSON package search. Fixes #597

### DIFF
--- a/CMakeModules/FindRapidJSON.cmake
+++ b/CMakeModules/FindRapidJSON.cmake
@@ -51,6 +51,7 @@ if (NOT RAPIDJSON_FOUND)
   ##____________________________________________________________________________
   ## Actions taken when all components have been found
 
+  include (FindPackageHandleStandardArgs)
   find_package_handle_standard_args (RAPIDJSON DEFAULT_MSG RAPIDJSON_INCLUDES)
 
   if (RAPIDJSON_FOUND)


### PR DESCRIPTION
`find_package_handle_standard_args()` could not be used without include of `FindPackageHandleStandardArgs`. See #597