### PR TITLE
Fix access beyond passed buffer when constructing RawBuffer

### DIFF
--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -34,8 +34,8 @@ RawBuffer::RawBuffer(const char* data, size_t length, bool isDetached)
     , length_(length)
     , isDetached_(isDetached)
 {
-    data_.resize(length_ + 1);
-    data_.assign(data, length_ + 1);
+    // input may come not from a ZTS - copy only length_ characters.
+    data_.assign(data, length_);
 }
 
 RawBuffer RawBuffer::detach(size_t fromIndex)

--- a/tests/stream_test.cc
+++ b/tests/stream_test.cc
@@ -29,7 +29,7 @@ TEST(stream, test_buffer)
     RawBuffer buffer4 = buffer3.detach(0);
     ASSERT_EQ(buffer4.size(), 0u);
     ASSERT_EQ(buffer4.isDetached(), false);
-    
+
     ASSERT_THROW(buffer1.detach(2 * len);, std::range_error);
 }
 
@@ -54,4 +54,24 @@ TEST(stream, test_file_buffer)
     ASSERT_EQ(fileBuffer.size(), dataToWrite.size());
 
     std::remove(fileName);
+}
+
+TEST(stream, test_dyn_buffer)
+{
+    DynamicStreamBuf buf(128);
+
+    {
+        std::ostream os(&buf);
+
+        for (unsigned i = 0; i < 128; ++i) {
+            os << "A";
+        }
+    }
+
+    auto rawbuf = buf.buffer();
+
+    ASSERT_EQ(rawbuf.size(), 128u);
+    ASSERT_EQ(rawbuf.isDetached(), false);
+    ASSERT_EQ(rawbuf.data().size(), 128u);
+    ASSERT_EQ(strlen(rawbuf.data().c_str()), 128u);
 }


### PR DESCRIPTION
e.g. DynamicStreamBuf passes pointer to internal vector, but RawBuffer
treats it as a null-terminated string, trying to read one char beyond.

Running provided unit-test under valgrind produced

> [ RUN      ] stream.test_dyn_buffer
> ==4206== Invalid read of size 1
> ==4206==    at 0x4C2EA70: memcpy@@GLIBC_2.14 (vg_replace_strmem.c:1035)
> ==4206==    by 0x442B1B: std::string::assign(char const*, unsigned long) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x4428DC: Pistache::RawBuffer::RawBuffer(char const*, unsigned long, bool) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x41ED7C: stream_test_dyn_buffer_Test::TestBody() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x4412B9: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438B8B: testing::Test::Run() [clone .part.408] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438D64: testing::TestInfo::Run() [clone .part.409] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438E79: testing::TestCase::Run() [clone .part.410] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x439429: testing::internal::UnitTestImpl::RunAllTests() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x441769: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x4395F7: testing::UnitTest::Run() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x41CFBF: main (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==  Address 0x9f15f90 is 0 bytes after a block of size 128 alloc'd
> ==4206==    at 0x4C2A4C3: operator new(unsigned long) (vg_replace_malloc.c:344)
> ==4206==    by 0x4420DF: Pistache::DynamicStreamBuf::reserve(unsigned long) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x41EC93: stream_test_dyn_buffer_Test::TestBody() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x4412B9: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438B8B: testing::Test::Run() [clone .part.408] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438D64: testing::TestInfo::Run() [clone .part.409] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x438E79: testing::TestCase::Run() [clone .part.410] (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x439429: testing::internal::UnitTestImpl::RunAllTests() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x441769: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x4395F7: testing::UnitTest::Run() (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206==    by 0x41CFBF: main (in /home/vbespalov/source/utils/pistache/build/tests/run_stream_test)
> ==4206== 
> [       OK ] stream.test_dyn_buffer (3 ms)