### PR TITLE
Common: Fix broken compilation for trees without the PISTACHE_USE_SSL option

### DIFF
--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -7,6 +7,8 @@
 #include <pistache/peer.h>
 #include <unistd.h>
 
+#ifdef PISTACHE_USE_SSL
+
 ssize_t SSL_sendfile(SSL *out, int in, off_t *offset, size_t count)
 {
     unsigned char       buffer[4096] = { 0 };
@@ -33,3 +35,5 @@ ssize_t SSL_sendfile(SSL *out, int in, off_t *offset, size_t count)
 
     return written;
 }
+
+#endif /* PISTACHE_USE_SSL */


### PR DESCRIPTION
Due to a brain-lag on my end, I've introduced a regression in commit
44e40478d604746963b898efd463a541ebbea824, because a SSL utility function
was compiling whether or not the SSL was enabled. It is now fixed,
apologies.

Pull Request: https://github.com/oktal/pistache/pull/623
Fixes: https://github.com/oktal/pistache/issues/621
Fixes: https://github.com/oktal/pistache/issues/622

Fork: Fork: https://git.mobley.ne02ptzero.me/~louis/pistache
Signed-off-by: Louis Solofrizzo <lsolofrizzo@online.net>