### PR TITLE
Raw and Cookie header case-insensitive

### DIFF
--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -28,6 +28,8 @@ struct LowercaseHash {
     }
 };
 
+bool LowercaseEqualStatic(const std::string& dynamic, const std::string& statik);
+
 struct LowercaseEqual {
     bool operator()(const std::string& left, const std::string& right) const {
         return std::equal(left.begin(), left.end(), right.begin(), right.end(),

--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -109,7 +109,7 @@ public:
 
     std::vector<std::shared_ptr<Header>> list() const;
 
-    const std::unordered_map<std::string, Raw>& rawList() const {
+    const std::unordered_map<std::string,Raw,LowercaseHash,LowercaseEqual>& rawList() const {
         return rawHeaders;
     }
 
@@ -126,7 +126,12 @@ private:
         LowercaseHash,
         LowercaseEqual
     > headers;
-    std::unordered_map<std::string, Raw> rawHeaders;
+    std::unordered_map<
+        std::string,
+        Raw,
+        LowercaseHash,
+        LowercaseEqual
+    > rawHeaders;
 };
 
 class Registry {

--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -30,8 +30,11 @@ struct LowercaseHash {
 
 struct LowercaseEqual {
     bool operator()(const std::string& left, const std::string& right) const {
-        return toLowercase(left) == toLowercase(right);
-    }
+        return std::equal(left.begin(), left.end(), right.begin(), right.end(),
+            [] (const char& a, const char& b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+    };
 };
 
 class Collection {

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -290,11 +290,11 @@ namespace Private {
                 if (!cursor.advance(1)) return State::Again;
             }
 
-            if (name == "Cookie") {
+            if (Header::LowercaseEqualStatic(name, "cookie")) {
                 message->cookies_.removeAllCookies(); // removing existing cookies before re-adding them.
                 message->cookies_.addFromRaw(cursor.offset(start), cursor.diff(start));
             }
-            else if (name == "Set-Cookie") {
+            else if (Header::LowercaseEqualStatic(name, "set-cookie")) {
                 message->cookies_.add(Cookie::fromRaw(cursor.offset(start), cursor.diff(start)));
             }
 

--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -41,6 +41,14 @@ toLowercase(std::string str) {
     return str;
 }
 
+bool
+LowercaseEqualStatic(const std::string& dynamic, const std::string& statik) {
+    return std::equal(dynamic.begin(), dynamic.end(), statik.begin(), statik.end(),
+        [] (const char& a, const char& b) {
+            return std::tolower(a) == b;
+        });
+}
+
 Registry& Registry::instance() {
     static Registry instance;
 

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -713,3 +713,29 @@ TEST(headers_test, raw_headers_are_case_insensitive)
     ASSERT_FALSE(request.headers().tryGetRaw("Custom-Header").isEmpty());
     ASSERT_FALSE(request.headers().tryGetRaw("custom-header").isEmpty());
 }
+
+
+TEST(headers_test, cookie_headers_are_case_insensitive)
+{
+    {
+        std::string line = "cookie: x=y\r\n";
+        Pistache::RawStreamBuf<> buf(&line[0], line.size());
+        Pistache::StreamCursor cursor(&buf);
+        Pistache::Http::Request request;
+        Pistache::Http::Private::HeadersStep step(&request);
+        step.apply(cursor);
+
+        ASSERT_TRUE(request.cookies().has("x"));
+    }
+
+    {
+        std::string line = "set-cookie: x=y\r\n";
+        Pistache::RawStreamBuf<> buf(&line[0], line.size());
+        Pistache::StreamCursor cursor(&buf);
+        Pistache::Http::Request request;
+        Pistache::Http::Private::HeadersStep step(&request);
+        step.apply(cursor);
+
+        ASSERT_TRUE(request.cookies().has("x"));
+    }
+}

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -702,40 +702,53 @@ TEST(headers_test, registered_header_in_raw_list)
 
 TEST(headers_test, raw_headers_are_case_insensitive)
 {
-    std::string line = "Custom-Header: x\r\n";
+    // no matter the casing of the input header,
+    std::vector<std::string> test_cases = {
+        "Custom-Header: x\r\n",
+        "CUSTOM-HEADER: x\r\n",
+        "custom-header: x\r\n",
+        "CuStOm-HeAdEr: x\r\n"
+    };
 
-    Pistache::RawStreamBuf<> buf(&line[0], line.size());
-    Pistache::StreamCursor cursor(&buf);
-    Pistache::Http::Request request;
-    Pistache::Http::Private::HeadersStep step(&request);
-    step.apply(cursor);
+    for(auto&& test : test_cases) {
+        Pistache::RawStreamBuf<> buf(&test[0], test.size());
+        Pistache::StreamCursor cursor(&buf);
+        Pistache::Http::Request request;
+        Pistache::Http::Private::HeadersStep step(&request);
+        step.apply(cursor);
 
-    ASSERT_FALSE(request.headers().tryGetRaw("Custom-Header").isEmpty());
-    ASSERT_FALSE(request.headers().tryGetRaw("custom-header").isEmpty());
+        // or the header you try and get, it should work:
+        ASSERT_FALSE(request.headers().tryGetRaw("Custom-Header").isEmpty());
+        ASSERT_FALSE(request.headers().tryGetRaw("CUSTOM-HEADER").isEmpty());
+        ASSERT_FALSE(request.headers().tryGetRaw("custom-header").isEmpty());
+        ASSERT_FALSE(request.headers().tryGetRaw("CuStOm-HeAdEr").isEmpty());
+    }
 }
 
 
 TEST(headers_test, cookie_headers_are_case_insensitive)
 {
-    {
-        std::string line = "cookie: x=y\r\n";
-        Pistache::RawStreamBuf<> buf(&line[0], line.size());
+    // no matter the casing of the cookie header(s),
+    std::vector<std::string> test_cases = {
+        "Cookie: x=y\r\n",
+        "COOKIE: x=y\r\n",
+        "cookie: x=y\r\n",
+        "CoOkIe: x=y\r\n",
+        "Set-Cookie: x=y\r\n",
+        "SET-COOKIE: x=y\r\n",
+        "set-cookie: x=y\r\n",
+        "SeT-CoOkIe: x=y\r\n",
+    };
+
+    for(auto&& test : test_cases) {
+        Pistache::RawStreamBuf<> buf(&test[0], test.size());
         Pistache::StreamCursor cursor(&buf);
         Pistache::Http::Request request;
         Pistache::Http::Private::HeadersStep step(&request);
         step.apply(cursor);
 
+        // the cookies should still exist.
         ASSERT_TRUE(request.cookies().has("x"));
-    }
-
-    {
-        std::string line = "set-cookie: x=y\r\n";
-        Pistache::RawStreamBuf<> buf(&line[0], line.size());
-        Pistache::StreamCursor cursor(&buf);
-        Pistache::Http::Request request;
-        Pistache::Http::Private::HeadersStep step(&request);
-        step.apply(cursor);
-
-        ASSERT_TRUE(request.cookies().has("x"));
+        ASSERT_TRUE(request.cookies().get("x").value == "y");
     }
 }

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -700,3 +700,16 @@ TEST(headers_test, registered_header_in_raw_list)
     ASSERT_TRUE(foundRawHeader->second.value() == "some data");
 }
 
+TEST(headers_test, raw_headers_are_case_insensitive)
+{
+    std::string line = "Custom-Header: x\r\n";
+
+    Pistache::RawStreamBuf<> buf(&line[0], line.size());
+    Pistache::StreamCursor cursor(&buf);
+    Pistache::Http::Request request;
+    Pistache::Http::Private::HeadersStep step(&request);
+    step.apply(cursor);
+
+    ASSERT_FALSE(request.headers().tryGetRaw("Custom-Header").isEmpty());
+    ASSERT_FALSE(request.headers().tryGetRaw("custom-header").isEmpty());
+}


### PR DESCRIPTION
fixes #604

I'm using pistache with nginx, with HTTP2 -> nginx proxy -> Pistache. As HTTP2 lowercases all headers, Cookie and other raw headers weren't working.

This PR:

* Adds case-insensitive matching for the Cookie and Set-Cookie header
* Adds case-insensitive lookups/hashing for rawHeaders
* Refactors the case-insensitive comparing to use less memory (_how is this actually not in c++ officially, omg_)
* Adds tests for raw headers and cookies