### PR TITLE
Allow IPv6 addresses without port number. Fixes oktal/pistache#625

### DIFF
--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -233,7 +233,7 @@ AddressParser::AddressParser(const std::string& data)
         family_ = AF_INET;
     }
     
-    if (end_pos != std::string::npos)
+    if (end_pos != std::string::npos && hasColon_)
     {
         port_ = data.substr(end_pos + 1);
         if (port_.empty())

--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -136,9 +136,14 @@ TEST(net_test, address_creation)
     ASSERT_EQ(address21.port(), 8080);
 
     Address address22("[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]");
-    ASSERT_EQ(address11.host(), "2001:db8:aabb:ccdd:eeff:11:2233:4455");
-    ASSERT_EQ(address11.family(), AF_INET6);
-    ASSERT_EQ(address11.port(), 8080);
+    ASSERT_EQ(address22.host(), "2001:db8:aabb:ccdd:eeff:11:2233:4455");
+    ASSERT_EQ(address22.family(), AF_INET6);
+    ASSERT_EQ(address22.port(), 80);
+
+    Address address23("[::]");
+    ASSERT_EQ(address23.host(), "::");
+    ASSERT_EQ(address23.family(), AF_INET6);
+    ASSERT_EQ(address23.port(), 80);
 
 }
 

--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -135,6 +135,11 @@ TEST(net_test, address_creation)
     ASSERT_EQ(address21.family(), AF_INET);
     ASSERT_EQ(address21.port(), 8080);
 
+    Address address22("[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]");
+    ASSERT_EQ(address11.host(), "2001:db8:aabb:ccdd:eeff:11:2233:4455");
+    ASSERT_EQ(address11.family(), AF_INET6);
+    ASSERT_EQ(address11.port(), 8080);
+
 }
 
 TEST(net_test, invalid_address)


### PR DESCRIPTION
As discussed in https://github.com/oktal/pistache/issues/625