### PR TITLE
Fix for segmentation fault caused by incorrect lambda capture in promise

### DIFF
--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -287,7 +287,7 @@ Transport::asyncWriteImpl(Fd fd)
                 // EBADF can happen when the HTTP parser, in the case of
                 // an error, closes fd before the entire request is processed.
                 // https://github.com/oktal/pistache/issues/501
-                else if (errno == EBADF) {
+                else if (errno == EBADF || errno == EPIPE || errno == ECONNRESET) {
                     wq.pop_front();
                     toWrite.erase(fd);
                     stop = true;


### PR DESCRIPTION
I am experiencing an issue with a single worker thread pistache server, debug build. I am serving a simple web page. I connect to the web page and repeatedly press refresh (F5) on my browser (Firefox). After a couple of resets I get a segfault.

Looking through the call stack and after some analysis, it seems that there is a promise created that captures its local scope. In edge cases, the promise would resolve after the object was deleted. The internal "Core" shared pointer would be cleared and this would lead to the segmentation fault.

The trigger for this case is getting an EPIPE or ECONNRESET, which should probably not be issuing a response anyhow since the fd is broken.

I can see that lambdas capturing the entire local scope is common in the code base. I would suggest that you avoid doing so to avoid referencing invalidated objects.

Also the error case for the asyncWriteImpl code by default tries to respond to the remote with a failed write error, which seems counter intuitive since not being able to write to the remote is probably an indication that you can't send data to him any more. I think it would be better if you explicitly specified the cases where it makes sense to send the error as a response. However, since I do not have much experience with the code I opted to take the least drastic approach. 