### PR TITLE
optional::operator== improvements

### DIFF
--- a/include/pistache/optional.h
+++ b/include/pistache/optional.h
@@ -240,13 +240,15 @@ public:
         }
     }
 
-    template<typename = typename std::enable_if<types::has_equalto_operator<T>::value>::type>
     bool operator==(const Optional<T>& other) const {
+        static_assert(types::has_equalto_operator<T>::value,
+                      "optional<T> requires T to be comparable by equal to operator");
         return (isEmpty() && other.isEmpty()) || (!isEmpty() && !other.isEmpty() && get() == other.get());
     }
 
-    template<typename = typename std::enable_if<types::has_equalto_operator<T>::value>::type>
     bool operator!=(const Optional<T>& other) const {
+        static_assert(types::has_equalto_operator<T>::value,
+                      "optional<T> requires T to be comparable by equal to operator");
         return !(*this == other);
    }
 

--- a/include/pistache/optional.h
+++ b/include/pistache/optional.h
@@ -240,12 +240,12 @@ public:
         }
     }
 
-    template<typename U = T, typename = typename std::enable_if<types::has_equalto_operator<U>::value>::type>
+    template<typename = typename std::enable_if<types::has_equalto_operator<T>::value>::type>
     bool operator==(const Optional<T>& other) const {
         return (isEmpty() && other.isEmpty()) || (!isEmpty() && !other.isEmpty() && get() == other.get());
     }
 
-    template<typename U = T, typename = typename std::enable_if<types::has_equalto_operator<U>::value>::type>
+    template<typename = typename std::enable_if<types::has_equalto_operator<T>::value>::type>
     bool operator!=(const Optional<T>& other) const {
         return !(*this == other);
    }

--- a/tests/optional_test.cc
+++ b/tests/optional_test.cc
@@ -163,7 +163,7 @@ struct not_comparable
     bool operator==(const not_comparable& other) const = delete;
 };
 
-TEST(optional, is_comparable_type)
+TEST(has_equalto_operator, is_comparable_type)
 {
     using Pistache::types::has_equalto_operator;
     EXPECT_FALSE(has_equalto_operator<not_comparable>::value);


### PR DESCRIPTION
1st commit : I don't think we need the extra type U which is only provided to has_equalto_operator<U> metafunction.
2nd commit : when a user provides a non-comparable type, then we state what they've done wrong instead of letting a compiler complain about the lack of operator== in optional<T>.
3rd commit : previous didn't test optional

However, now has_equalto_operator<Optional<not_comparable>>::value will return a different value (but it's still technically correct) :D @muttleyxd what do you think?