### PR TITLE
close non-closed file descriptor will resolve : #38, #43, #150, #164, #221 - shutdown will work properly 

### DIFF
--- a/include/pistache/os.h
+++ b/include/pistache/os.h
@@ -99,6 +99,7 @@ struct Event {
 class Epoll {
 public:
     Epoll();
+    ~Epoll(); 
 
     void addFd(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode = Mode::Level);
     void addFdOneShot(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode = Mode::Level);

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -147,6 +147,14 @@ namespace Polling {
        epoll_fd = TRY_RET(epoll_create(Const::MaxEvents));
     }
 
+    Epoll::~Epoll()
+    {
+        if (epoll_fd > 0)
+        {
+            close(epoll_fd);
+        }
+    }
+        
     void
     Epoll::addFd(Fd fd, Flags<NotifyOn> interest, Tag tag, Mode mode) {
         struct epoll_event ev;

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -149,7 +149,7 @@ namespace Polling {
 
     Epoll::~Epoll()
     {
-        if (epoll_fd > 0)
+        if (epoll_fd >= 0)
         {
             close(epoll_fd);
         }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -96,10 +96,10 @@ Listener::~Listener() {
     if (acceptThread.joinable())
         acceptThread.join();
    
-    if (listen_fd > 0)
+    if (listen_fd >= 0)
     {
         close(listen_fd);
-        listen_fd = 0;
+        listen_fd = -1;
     }    
 #ifdef PISTACHE_USE_SSL
     if (this->useSSL_)

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -95,6 +95,12 @@ Listener::~Listener() {
         shutdown();
     if (acceptThread.joinable())
         acceptThread.join();
+   
+    if (listen_fd > 0)
+    {
+        close(listen_fd);
+        listen_fd = 0;
+    }    
 #ifdef PISTACHE_USE_SSL
     if (this->useSSL_)
     {


### PR DESCRIPTION
This PR introduces changes which resolve these issues (#38, #43, #150, #164, #221).

the file descriptor will stay open at the end of the Listener and Epoll life-time, there for the shutdown will not work properly, and may get the Bad file descriptor in multi threading and also Too many open files. 
it just close the listener port and FD and close FD in epoll deconstructor. 