### PR TITLE
Declared CacheDirective single-argument constructor as 'explicit'.

### DIFF
--- a/include/pistache/http_defs.h
+++ b/include/pistache/http_defs.h
@@ -160,7 +160,7 @@ public:
         , data()
     { }
 
-    CacheDirective(Directive directive);
+    explicit CacheDirective(Directive directive);
     CacheDirective(Directive directive, std::chrono::seconds delta);
 
     Directive directive() const { return directive_; }

--- a/include/pistache/http_header.h
+++ b/include/pistache/http_header.h
@@ -289,6 +289,9 @@ public:
         : directives_(directives)
     { }
     explicit CacheControl(Http::CacheDirective directive);
+    explicit CacheControl(Http::CacheDirective::Directive directive):
+      CacheControl(Http::CacheDirective(directive))
+    { }
 
     void parseRaw(const char* str, size_t len) override;
     void write(std::ostream& os) const override;
@@ -296,6 +299,9 @@ public:
     std::vector<Http::CacheDirective> directives() const { return directives_; }
 
     void addDirective(Http::CacheDirective directive);
+    void addDirective(Http::CacheDirective::Directive directive) {
+        addDirective(Http::CacheDirective(directive));
+    }
     void addDirectives(const std::vector<Http::CacheDirective>& directives);
 
 private:
@@ -424,6 +430,9 @@ public:
 
     explicit ContentType(const Mime::MediaType& mime)
         : mime_(mime)
+    { }
+    explicit ContentType(std::string raw_mime_str)
+        : ContentType(Mime::MediaType(raw_mime_str))
     { }
 
     void parseRaw(const char* str, size_t len) override;

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -60,9 +60,11 @@ TEST(headers_test, accept)
 
     Pistache::Http::Header::Accept a4;
     ASSERT_THROW(a4.parse("text/*;q=0.4, text/html;q=0.3,"), std::runtime_error);
+    /* Shameless dummy comment to work around syntax highlighting bug in nano... */
 
     Pistache::Http::Header::Accept a5;
     ASSERT_THROW(a5.parse("text/*;q=0.4, text/html;q=0.3, "), std::runtime_error);
+    /* Shameless dummy comment to work around syntax highlighting bug in nano... */
 }
 
 TEST(headers_test, allow)
@@ -220,7 +222,10 @@ TEST(headers_test, cache_control)
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc12;
-    cc12.addDirectives({Pistache::Http::CacheDirective::Public, Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::MaxAge, std::chrono::seconds(600))});
+    cc12.addDirectives({
+      Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::Public),
+      Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::MaxAge, std::chrono::seconds(600))
+    });
     cc12.write(oss);
     ASSERT_TRUE(oss.str() == "public, max-age=600");
     oss.str("");
@@ -228,7 +233,7 @@ TEST(headers_test, cache_control)
     Pistache::Http::Header::CacheControl cc13;
     std::vector<Pistache::Http::CacheDirective> cd;
 
-    cd.push_back(Pistache::Http::CacheDirective::Public);
+    cd.push_back(Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::Public));
     cd.push_back(Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::MaxAge, std::chrono::seconds(600)));
 
     cc13.addDirectives(cd);


### PR DESCRIPTION
The rest is fallout / fix ups due to that.