### PR TITLE
Fix Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,10 @@ if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
         set(CMAKE_CXX_STANDARD 14)
     endif()
 else()
-    # Clang exports C++17 in std::experimental namespace (tested on Clang 5 and 6).
+    # Old versions of Clang export C++17 in std::experimental namespace (tested on Clang 5 and 6).
     # This gives an error on date.h external library.
-    # Following workaround forces Clang to compile at best with C++14
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Following workaround forces Clang <= 6 to compile at best with C++14
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.0))
         set(CMAKE_CXX_STANDARD 14)
     elseif (CMAKE_COMPILER_IS_GNUCC)
         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
@@ -75,6 +75,9 @@ endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 if (PISTACHE_USE_SSL)
     add_definitions(-DPISTACHE_USE_SSL)

--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <limits>
 
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <netdb.h>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,8 +26,8 @@ set(bin_install_dir ${CMAKE_INSTALL_BINDIR})
 add_library(pistache_shared SHARED $<TARGET_OBJECTS:pistache>)
 add_library(pistache_static STATIC $<TARGET_OBJECTS:pistache>)
 
-target_link_libraries(pistache_shared pthread)
-target_link_libraries(pistache_static pthread)
+target_link_libraries(pistache_shared Threads::Threads)
+target_link_libraries(pistache_static Threads::Threads)
 
 set(Pistache_OUTPUT_NAME "pistache")
 set_target_properties(pistache_shared PROPERTIES


### PR DESCRIPTION
I haven't tested the built library in practice yet, but at least it compiles on Android now.

* Clang workaround to disable C++17 (and compile with C++14 instead) broke the build due to conflicts in pistache's `string_view` implementation. Luckily the WA is not necessary with Clang 8 anymore and hence is enabled for old compiler versions only now. (Clang 7 has not been tested but is assumed to be fine).
* net.h was missing an include for `struct sockaddr_in`
* `pthreads` dependency is now discovered using CMake's FindThreads module (required on Android since pthreads is built into the core NDK and hence requires no explicit link flags)