### PR TITLE
Modify reactor.cc to c++14

### DIFF
--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -342,11 +342,11 @@ public:
   std::vector<std::shared_ptr<Handler>>
   handlers(const Reactor::Key &key) const override {
 
-    const auto [idx, marker] = decodeKey(key);
-    if (marker != KeyMarker)
+    const std::pair<uint32_t, uint32_t> idx_marker = decodeKey(key);
+    if (idx_marker.second != KeyMarker)
       throw std::runtime_error("Invalid key");
 
-    Reactor::Key originalKey(idx);
+    Reactor::Key originalKey(idx_marker.first);
 
     std::vector<std::shared_ptr<Handler>> res;
     res.reserve(workers_.size());


### PR DESCRIPTION
I am using Pistache with [ROS](https://www.ros.org/), in [ubuntu xenial](http://br.releases.ubuntu.com/16.04/), so I need C++14, I want to use the GCC version distributed for my current system. When I started, I searched for other libraries to do the same, but Pistache was the best, considering simplicity, compatibility and features, so nice work to you all!

This is just a patch to allow the Pistache library to still be compiled with c++14. In my opinion, even thought we are in 2020, as this is an API, a higher compatibility should be aimed.

Hoping that you accept my PR,

closes #666 @dennisjenkins75 @kiplingw 