### PR TITLE
Address array and vector storage through .data()

### DIFF
--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -159,12 +159,12 @@ public:
   }
 
   RawBuffer buffer() const {
-    return RawBuffer((const char *)data_.data(), pptr() - &data_[0]);
+    return RawBuffer(data_.data(), pptr() - data_.data());
   }
 
   void clear() {
-    data_.clear();
-    this->setp(&data_[0], &data_[0] + data_.capacity());
+    // reset stream buffer to the whole backing storage.
+    this->setp(data_.data(), data_.data() + data_.size());
   }
 
 protected:

--- a/include/pistache/view.h
+++ b/include/pistache/view.h
@@ -142,7 +142,7 @@ template <typename T, size_t N> struct ViewBuilder<std::array<T, N>> {
     if (size > arr.size())
       throw std::invalid_argument("out of bounds size");
 
-    return View<T>(&arr[0], size);
+    return View<T>(arr.data(), size);
   }
 };
 
@@ -170,7 +170,7 @@ template <typename T> struct ViewBuilder<std::vector<T>> {
     if (size > vec.size())
       throw std::invalid_argument("out of bounds size");
 
-    return View<T>(&vec[0], size);
+    return View<T>(vec.data(), size);
   }
 };
 

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -28,7 +28,7 @@ static constexpr const char *UA = "pistache/0.1";
 
 namespace {
 std::pair<StringView, StringView> splitUrl(const std::string &url) {
-  RawStreamBuf<char> buf(const_cast<char *>(&url[0]), url.size());
+  RawStreamBuf<char> buf(const_cast<char *>(url.data()), url.size());
   StreamCursor cursor(&buf);
 
   match_string("http://", cursor);

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -95,7 +95,7 @@ void DynamicStreamBuf::reserve(size_t size) {
     size = maxSize;
   const size_t oldSize = data_.size();
   data_.resize(size);
-  this->setp(&data_[0] + oldSize, &data_[0] + size);
+  this->setp(data_.data() + oldSize, data_.data() + size);
 }
 
 bool StreamCursor::advance(size_t count) {


### PR DESCRIPTION
When used like &vec[0], there would be an assert in gnu std lib:

/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type)
[with _Tp = char; _Alloc = std::allocator<char>; std::vector<_Tp, _Alloc>::reference = char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]:
Assertion '__builtin_expect(__n < this->size(), true)' failed.

on the other hand, using .data() is allowed even on empty uninited vectors

array<> access is modified for consistency.