### PR TITLE
Remove friend relationship in Connection class

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -27,12 +27,9 @@
 namespace Pistache {
 namespace Http {
 
-class ConnectionPool;
 class Transport;
 
 struct Connection : public std::enable_shared_from_this<Connection> {
-
-  friend class ConnectionPool;
 
   using OnDone = std::function<void()>;
 
@@ -58,6 +55,8 @@ struct Connection : public std::enable_shared_from_this<Connection> {
   void connect(const Address &addr);
   void close();
   bool isIdle() const;
+  bool tryUse();
+  void setAsIdle();
   bool isConnected() const;
   bool hasTransport() const;
   void associateTransport(const std::shared_ptr<Transport> &transport);


### PR DESCRIPTION
Hello,

In my opinion the following relationship between classes can be removed:
```
friend class ConnectionPool;
```
Instead it, I'm proposing to use corresponding methods. If I'm not mistaken it would be better to hide the internal states of objects.