### PR TITLE
Handle exceptions on responce parse in client

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -565,8 +565,7 @@ void Connection::handleResponsePacket(const char *buffer, size_t totalBytes) {
           onDone();
       }
     }
-  }
-  catch (const std::exception &ex) {
+  } catch (const std::exception &ex) {
     handleError(ex.what());
   }
 }


### PR DESCRIPTION
It's possible that `parse()` method can throw an exception. In the current client implementation uncaught exception can happen.