### PR TITLE
Code simplification in Peer class and small fix in Listener

### DIFF
--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -142,6 +142,7 @@ public:
   Address &operator=(Address &&other) = default;
 
   static Address fromUnix(struct sockaddr *addr);
+  static Address fromUnix(struct sockaddr_in *addr);
 
   std::string host() const;
   Port port() const;

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -36,14 +36,12 @@ class Peer {
 public:
   friend class Transport;
 
-  Peer();
-  explicit Peer(const Address &addr);
   ~Peer();
+
+  static std::shared_ptr<Peer> Create(Fd fd, const Address &addr);
 
   const Address &address() const;
   const std::string &hostname();
-
-  void associateFd(Fd fd);
   Fd fd() const;
 
   void associateSSL(void *ssl);
@@ -58,20 +56,23 @@ public:
 
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
 
+protected:
+  Peer(Fd fd, const Address &addr);
+
 private:
   void associateTransport(Transport *transport);
   Transport *transport() const;
 
-  Transport *transport_;
+  Transport *transport_ = nullptr;
+  Fd fd_ = -1;
   Address addr;
-  Fd fd_;
 
   std::string hostname_;
   std::unordered_map<std::string,
                      std::shared_ptr<Pistache::Http::Private::ParserBase>>
       data_;
 
-  void *ssl_;
+  void *ssl_ = nullptr;
 };
 
 std::ostream &operator<<(std::ostream &os, Peer &peer);

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -248,6 +248,10 @@ Address Address::fromUnix(struct sockaddr *addr) {
   throw Error("Not an IP socket");
 }
 
+Address Address::fromUnix(struct sockaddr_in *addr) {
+  return Address::fromUnix((struct sockaddr *)&addr);
+}
+
 std::string Address::host() const { return ip_.toString(); }
 
 Port Address::port() const { return port_; }

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -249,7 +249,7 @@ Address Address::fromUnix(struct sockaddr *addr) {
 }
 
 Address Address::fromUnix(struct sockaddr_in *addr) {
-  return Address::fromUnix((struct sockaddr *)&addr);
+  return Address::fromUnix(reinterpret_cast<struct sockaddr *>(addr));
 }
 
 std::string Address::host() const { return ip_.toString(); }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -336,7 +336,7 @@ void Listener::handleNewConnection() {
   make_non_blocking(client_fd);
 
   auto peer =
-      Peer::Create(client_fd, Address::fromUnix((struct sockaddr *)&peer_addr));
+      Peer::Create(client_fd, Address::fromUnix(&peer_addr));
 
 #ifdef PISTACHE_USE_SSL
   if (this->useSSL_)

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -316,8 +316,10 @@ void Listener::handleNewConnection() {
   if (this->useSSL_) {
 
     ssl = SSL_new((SSL_CTX *)this->ssl_ctx_);
-    if (ssl == NULL)
+    if (ssl == NULL) {
+      close(client_fd);
       throw std::runtime_error("Cannot create SSL connection");
+    }
 
     SSL_set_fd(ssl, client_fd);
     SSL_set_accept_state(ssl);
@@ -334,8 +336,7 @@ void Listener::handleNewConnection() {
   make_non_blocking(client_fd);
 
   auto peer =
-      std::make_shared<Peer>(Address::fromUnix((struct sockaddr *)&peer_addr));
-  peer->associateFd(client_fd);
+      Peer::Create(client_fd, Address::fromUnix((struct sockaddr *)&peer_addr));
 
 #ifdef PISTACHE_USE_SSL
   if (this->useSSL_)


### PR DESCRIPTION
1) Code simplification in `Listener` and `Peer`: in my opiniton it would be better create `Peer` only using factory method and not allow user to associate some date (for instance, `fd`) later;
2) Add `fromUnix` overloading to `Address` to improve code in `Listener`;
3) Add `client_fd`socket  closing in the case when memory for SSL cannot be allocated.