### PR TITLE
Improve Peer SSL API and remove unnecessary code

### DIFF
--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -39,13 +39,13 @@ public:
   ~Peer();
 
   static std::shared_ptr<Peer> Create(Fd fd, const Address &addr);
+  static std::shared_ptr<Peer> CreateSSL(Fd fd, const Address &addr, void *ssl);
 
   const Address &address() const;
   const std::string &hostname();
   Fd fd() const;
 
-  void associateSSL(void *ssl);
-  void *ssl(void) const;
+  void *ssl() const;
 
   void putData(std::string name,
                std::shared_ptr<Pistache::Http::Private::ParserBase> data);
@@ -57,7 +57,7 @@ public:
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
 
 protected:
-  Peer(Fd fd, const Address &addr);
+  Peer(Fd fd, const Address &addr, void *ssl);
 
 private:
   void associateTransport(Transport *transport);

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -21,21 +21,26 @@ namespace Tcp {
 namespace {
 struct ConcretePeer : Peer {
   ConcretePeer() = default;
-  ConcretePeer(Fd fd, const Address &addr) : Peer(fd, addr) {}
+  ConcretePeer(Fd fd, const Address &addr, void *ssl) : Peer(fd, addr, ssl) {}
 };
 } // namespace
 
-Peer::Peer(Fd fd, const Address &addr) : fd_(fd), addr(addr) {}
+Peer::Peer(Fd fd, const Address &addr, void *ssl)
+    : fd_(fd), addr(addr), ssl_(ssl) {}
 
 Peer::~Peer() {
 #ifdef PISTACHE_USE_SSL
   if (ssl_)
-    SSL_free((SSL *)ssl_);
+    SSL_free(static_cast<SSL *>(ssl_));
 #endif /* PISTACHE_USE_SSL */
 }
 
 std::shared_ptr<Peer> Peer::Create(Fd fd, const Address &addr) {
-  return std::make_shared<ConcretePeer>(fd, addr);
+  return std::make_shared<ConcretePeer>(fd, addr, nullptr);
+}
+
+std::shared_ptr<Peer> Peer::CreateSSL(Fd fd, const Address &addr, void *ssl) {
+  return std::make_shared<ConcretePeer>(fd, addr, ssl);
 }
 
 const Address &Peer::address() const { return addr; }
@@ -61,9 +66,7 @@ const std::string &Peer::hostname() {
 }
 
 #ifdef PISTACHE_USE_SSL
-void Peer::associateSSL(void *ssl) { ssl_ = ssl; }
-
-void *Peer::ssl(void) const { return ssl_; }
+void *Peer::ssl() const { return ssl_; }
 #endif /* PISTACHE_USE_SSL */
 
 int Peer::fd() const {

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -65,9 +65,7 @@ const std::string &Peer::hostname() {
   return hostname_;
 }
 
-#ifdef PISTACHE_USE_SSL
 void *Peer::ssl() const { return ssl_; }
-#endif /* PISTACHE_USE_SSL */
 
 int Peer::fd() const {
   if (fd_ == -1) {

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -165,13 +165,6 @@ void Transport::handlePeerDisconnection(const std::shared_ptr<Peer> &peer) {
   if (it == std::end(peers))
     throw std::runtime_error("Could not find peer to erase");
 
-#ifdef PISTACHE_USE_SSL
-  if (peer->ssl() != NULL) {
-    SSL_free((SSL *)peer->ssl());
-    peer->associateSSL(NULL);
-  }
-#endif /* PISTACHE_USE_SSL */
-
   peers.erase(it->first);
 
   {

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -335,13 +335,12 @@ void Listener::handleNewConnection() {
 
   make_non_blocking(client_fd);
 
-  auto peer =
-      Peer::Create(client_fd, Address::fromUnix(&peer_addr));
-
-#ifdef PISTACHE_USE_SSL
-  if (this->useSSL_)
-    peer->associateSSL(ssl);
-#endif /* PISTACHE_USE_SSL */
+  std::shared_ptr<Peer> peer;
+  if (this->useSSL_) {
+    peer = Peer::CreateSSL(client_fd, Address::fromUnix(&peer_addr), ssl);
+  } else {
+    peer = Peer::Create(client_fd, Address::fromUnix(&peer_addr));
+  }
 
   dispatchPeer(peer);
 }


### PR DESCRIPTION
Hello,

I this pull request I'm doing two things:
1) Improved `Peer` API in case of SSL;
2) Delete `associateSSL` call because I consider it useless, `SSL_free` will be called in `Peer` destructor.

What do you think about these changes?