### PR TITLE
Tell Travis to build on all of its supported CPU architectures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
 
   # Print debug system information
   - cat /proc/sys/kernel/core_pattern
-  - cat /etc/default/apport
+  - cat /etc/default/apport || true
   - service --status-all || true
   - initctl list || true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,18 +72,6 @@ matrix:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['apport', 'g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
 
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-9
-      - COV_TOOL=gcov-9
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['apport', 'g++-9', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
-
-
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ branches:
   only:
     - master
 
+arch:
+  - amd64
+  - ppc64le
+  - s390x
+  - arm64
+
 matrix:
   include:
   # Linux clang builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-dist: trusty
+dist: bionic
 sudo: true
 
 branches:
@@ -71,6 +71,18 @@ matrix:
       apt:
         sources: ['ubuntu-toolchain-r-test']
         packages: ['apport', 'g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
+
+  - os: linux
+    compiler: gcc
+    env:
+      - COMPILER=g++-9
+      - COV_TOOL=gcov-9
+      - COV_TOOL_ARGS=
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['apport', 'g++-9', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
+
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-        packages: [ 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
+        packages: [ 'apport', 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   - os: linux
     compiler: clang
@@ -36,7 +36,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-        packages: [ 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
+        packages: [ 'apport', 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   - os: linux
     compiler: clang
@@ -47,7 +47,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-        packages: [ 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
+        packages: [ 'apport', 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   # Linux GCC builds
   - os: linux
@@ -59,7 +59,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-7', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
+        packages: ['apport', 'g++-7', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
 
   - os: linux
     compiler: gcc
@@ -70,7 +70,7 @@ matrix:
     addons:
       apt:
         sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
+        packages: ['apport', 'g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck']
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"


### PR DESCRIPTION
Currently Travis CI is only building on amd64. This adds [support](https://docs.travis-ci.com/user/multi-cpu-architectures/) for IBM Z series (`s390x`), IBM POWER 8 / 9 (`ppc64el`, aka ppc64el in Travis' nomenclature), and ARMv8 (`arm64`). This is necessary in order to more reliably screen for portability issues.