### PR TITLE
Add version of bind() that can bind to shared_ptrs

### DIFF
--- a/include/pistache/route_bind.h
+++ b/include/pistache/route_bind.h
@@ -49,6 +49,19 @@ Route::Handler bind(Result (Cls::*func)(Args...), Obj obj) {
 #undef CALL_MEMBER_FN
 }
 
+template <typename Result, typename Cls, typename... Args, typename Obj>
+Route::Handler bind(Result (Cls::*func)(Args...), std::shared_ptr<Obj> objPtr) {
+  details::static_checks<Args...>();
+
+#define CALL_SHARED_PTR_MEMBER_FN(objPtr, pmf) (((objPtr).get())->*(pmf))
+
+  return [=](const Rest::Request &request, Http::ResponseWriter response) {
+    CALL_SHARED_PTR_MEMBER_FN(objPtr, func)(request, std::move(response));
+  };
+
+#undef CALL_SHARED_PTR_MEMBER_FN
+}
+
 template <typename Result, typename... Args>
 Route::Handler bind(Result (*func)(Args...)) {
   details::static_checks<Args...>();

--- a/include/pistache/route_bind.h
+++ b/include/pistache/route_bind.h
@@ -40,26 +40,18 @@ template <typename Result, typename Cls, typename... Args, typename Obj>
 Route::Handler bind(Result (Cls::*func)(Args...), Obj obj) {
   details::static_checks<Args...>();
 
-#define CALL_MEMBER_FN(obj, pmf) ((obj)->*(pmf))
-
   return [=](const Rest::Request &request, Http::ResponseWriter response) {
-    CALL_MEMBER_FN(obj, func)(request, std::move(response));
+    (obj->*func)(request, std::move(response));
   };
-
-#undef CALL_MEMBER_FN
 }
 
 template <typename Result, typename Cls, typename... Args, typename Obj>
 Route::Handler bind(Result (Cls::*func)(Args...), std::shared_ptr<Obj> objPtr) {
   details::static_checks<Args...>();
 
-#define CALL_SHARED_PTR_MEMBER_FN(objPtr, pmf) (((objPtr).get())->*(pmf))
-
   return [=](const Rest::Request &request, Http::ResponseWriter response) {
-    CALL_SHARED_PTR_MEMBER_FN(objPtr, func)(request, std::move(response));
+    (objPtr.get()->*func)(request, std::move(response));
   };
-
-#undef CALL_SHARED_PTR_MEMBER_FN
 }
 
 template <typename Result, typename... Args>

--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -325,30 +325,22 @@ template <typename Result, typename Cls, typename... Args, typename Obj>
 Route::Handler bind(Result (Cls::*func)(Args...), Obj obj) {
   details::static_checks<Args...>();
 
-#define CALL_MEMBER_FN(obj, pmf) ((obj)->*(pmf))
-
   return [=](const Rest::Request &request, Http::ResponseWriter response) {
-    CALL_MEMBER_FN(obj, func)(request, std::move(response));
+    (obj->*func)(request, std::move(response));
 
     return Route::Result::Ok;
   };
-
-#undef CALL_MEMBER_FN
 }
 
 template <typename Result, typename Cls, typename... Args, typename Obj>
 Route::Handler bind(Result (Cls::*func)(Args...), std::shared_ptr<Obj> objPtr) {
   details::static_checks<Args...>();
 
-#define CALL_SHARED_PTR_MEMBER_FN(objPtr, pmf) (((objPtr).get())->*(pmf))
-
   return [=](const Rest::Request &request, Http::ResponseWriter response) {
-    CALL_SHARED_PTR_MEMBER_FN(objPtr, func)(request, std::move(response));
+    (objPtr.get()->*func)(request, std::move(response));
 
     return Route::Result::Ok;
   };
-
-#undef CALL_SHARED_PTR_MEMBER_FN
 }
 
 template <typename Result, typename... Args>

--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -336,6 +336,21 @@ Route::Handler bind(Result (Cls::*func)(Args...), Obj obj) {
 #undef CALL_MEMBER_FN
 }
 
+template <typename Result, typename Cls, typename... Args, typename Obj>
+Route::Handler bind(Result (Cls::*func)(Args...), std::shared_ptr<Obj> objPtr) {
+  details::static_checks<Args...>();
+
+#define CALL_SHARED_PTR_MEMBER_FN(objPtr, pmf) (((objPtr).get())->*(pmf))
+
+  return [=](const Rest::Request &request, Http::ResponseWriter response) {
+    CALL_SHARED_PTR_MEMBER_FN(objPtr, func)(request, std::move(response));
+
+    return Route::Result::Ok;
+  };
+
+#undef CALL_SHARED_PTR_MEMBER_FN
+}
+
 template <typename Result, typename... Args>
 Route::Handler bind(Result (*func)(Args...)) {
   details::static_checks<Args...>();


### PR DESCRIPTION
`std::bind()` can handle `std::shared_ptr`s just fine, so at first I expected `Routes::bind()` to handle them as well. However, it does not, since it simply doesn't actually use `std::bind()`.