### PR TITLE
ResponseWriter caputres response size (bytes) for use after send().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,14 @@ before_script:
     -DPISTACHE_BUILD_TESTS=true
     -DPISTACHE_USE_SSL=true
 
+  # Debug build, no SSL
+  - cmake -H.
+    -BBuild-Debug-nossl
+    -DCMAKE_BUILD_TYPE=Debug
+    -DPISTACHE_BUILD_EXAMPLES=true
+    -DPISTACHE_BUILD_TESTS=true
+    -DPISTACHE_USE_SSL=false
+
   # Release build
   - cmake -H.
     -BBuild-Release
@@ -102,6 +110,10 @@ before_script:
 script:
   # Debug build
   - cd Build-Debug
+  - make -j 2 all test ARGS="-V"
+
+  # Debug build, no SSL
+  - cd Build-Debug-nossl
   - make -j 2 all test ARGS="-V"
 
   # Release build

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -402,6 +402,18 @@ public:
 
   std::shared_ptr<Tcp::Peer> peer() const;
 
+  // Expose the response size and code so that user-supplied logger can
+  // access them.  Perhaps we should fully expose the response_ instead?
+  //     const Response& getResponse() const { return respose_; }
+
+  size_t getResponseSize() const {
+    return response_.body().size();
+  }
+
+  Code getResponseCode() const {
+    return response_.code();
+  }
+
   // Unsafe API
 
   DynamicStreamBuf *rdbuf();

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -402,17 +402,12 @@ public:
 
   std::shared_ptr<Tcp::Peer> peer() const;
 
-  // Expose the response size and code so that user-supplied logger can
-  // access them.  Perhaps we should fully expose the response_ instead?
-  //     const Response& getResponse() const { return respose_; }
+  // Returns total count of HTTP bytes (headers, cookies, body) written when
+  // sending the response.  Result valid AFTER ResponseWriter.send() is called.
+  ssize_t getResponseSize() const { return sent_bytes_; }
 
-  size_t getResponseSize() const {
-    return response_.body().size();
-  }
-
-  Code getResponseCode() const {
-    return response_.code();
-  }
+  // Returns HTTP result code that was sent with the response.
+  Code getResponseCode() const { return response_.code(); }
 
   // Unsafe API
 
@@ -439,6 +434,7 @@ private:
   DynamicStreamBuf buf_;
   Tcp::Transport *transport_;
   Timeout timeout_;
+  ssize_t sent_bytes_;
 };
 
 Async::Promise<ssize_t>


### PR DESCRIPTION
1. Add method ResponseWriter::getResponseSize() (returns size_t)
1. Add method ResponseWriter::getResponseCode() (returns Http::Code)
1. Added unit test of the same.
1. Formatted the 3 modified files w/ clang-format

This addresses an issue raised in https://github.com/oktal/pistache/pull/695