### PR TITLE
Exploring flaky tests: more logs and several improvements

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -170,10 +170,6 @@ void Listener::bind(const Address &address) {
     throw std::runtime_error(strerror(errno));
   }
 
-  if (fd == -1) {
-    throw SocketError(strerror(errno));
-  }
-
   make_non_blocking(fd);
   poller.addFd(fd, Flags<Polling::NotifyOn>(Polling::NotifyOn::Read),
                Polling::Tag(fd));

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -170,6 +170,10 @@ void Listener::bind(const Address &address) {
     throw std::runtime_error(strerror(errno));
   }
 
+  if (fd == -1) {
+    throw SocketError(strerror(errno));
+  }
+
   make_non_blocking(fd);
   poller.addFd(fd, Flags<Polling::NotifyOn>(Polling::NotifyOn::Read),
                Polling::Tag(fd));
@@ -315,7 +319,7 @@ void Listener::handleNewConnection() {
 #ifdef PISTACHE_USE_SSL
   if (this->useSSL_) {
 
-    SSL* ssl_data = SSL_new((SSL_CTX *)this->ssl_ctx_);
+    SSL *ssl_data = SSL_new((SSL_CTX *)this->ssl_ctx_);
     if (ssl_data == nullptr) {
       close(client_fd);
       throw std::runtime_error("Cannot create SSL connection");
@@ -330,7 +334,7 @@ void Listener::handleNewConnection() {
       close(client_fd);
       return;
     }
-    ssl = static_cast<void*>(ssl_data);
+    ssl = static_cast<void *>(ssl_data);
   }
 #endif /* PISTACHE_USE_SSL */
 
@@ -391,7 +395,7 @@ static SSL_CTX *ssl_create_context(const std::string &cert,
     }
   }
 
-  /* Function introduced in 1.0.2 */
+/* Function introduced in 1.0.2 */
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
   SSL_CTX_set_ecdh_auto(ctx, 1);
 #endif /* OPENSSL_VERSION_NUMBER */
@@ -438,13 +442,13 @@ void Listener::setupSSLAuth(const std::string &ca_file,
   SSL_CTX_set_verify((SSL_CTX *)this->ssl_ctx_,
                      SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT |
                          SSL_VERIFY_CLIENT_ONCE,
-  /* Callback type did change in 1.0.1 */
+/* Callback type did change in 1.0.1 */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
                      (int (*)(int, X509_STORE_CTX *))cb
 #else
                      (SSL_verify_cb)cb
 #endif /* OPENSSL_VERSION_NUMBER */
-  );
+                     );
 }
 
 void Listener::setupSSL(const std::string &cert_path,

--- a/tests/http_server_test.cc
+++ b/tests/http_server_test.cc
@@ -16,7 +16,9 @@ using namespace Pistache;
 struct HelloHandlerWithDelay : public Http::Handler {
   HTTP_PROTOTYPE(HelloHandlerWithDelay)
 
-  explicit HelloHandlerWithDelay(int delay = 0) : delay_(delay) {}
+  explicit HelloHandlerWithDelay(int delay = 0) : delay_(delay) {
+    std::cout << "Init Hello handler with " << delay_ << " seconds delay\n";
+  }
 
   void onRequest(const Http::Request & /*request*/,
                  Http::ResponseWriter writer) override {
@@ -187,11 +189,12 @@ TEST(http_server_test, multiple_client_with_requests_to_multithreaded_server) {
   auto flags = Tcp::Options::ReuseAddr;
   auto server_opts = Http::Endpoint::options().flags(flags).threads(3);
   server.init(server_opts);
+  std::cout << "Trying to run server...\n";
   server.setHandler(Http::make_handler<HelloHandlerWithDelay>());
-  server.serveThreaded();
+  ASSERT_NO_THROW(server.serveThreaded());
 
   const std::string server_address = "localhost:" + server.getPort().toString();
-  std::cout << "Server address: " << server_address << "\n";
+  std::cout << "Server is running: " << server_address << "\n";
 
   const int NO_TIMEOUT = 0;
   const int SIX_SECONDS_TIMOUT = 6;

--- a/tests/https_server_test.cc
+++ b/tests/https_server_test.cc
@@ -73,13 +73,14 @@ TEST(http_client_test, basic_tls_request) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   res = curl_easy_perform(curl);
-  ASSERT_EQ(res, CURLE_OK);
-  ASSERT_EQ(buffer, "Hello, World!");
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   server.shutdown();
+
+  ASSERT_EQ(res, CURLE_OK);
+  ASSERT_EQ(buffer, "Hello, World!");
 }
 
 TEST(http_client_test, basic_tls_request_with_auth) {
@@ -115,13 +116,14 @@ TEST(http_client_test, basic_tls_request_with_auth) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   res = curl_easy_perform(curl);
-  ASSERT_EQ(res, CURLE_OK);
-  ASSERT_EQ(buffer, "Hello, World!");
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   server.shutdown();
+
+  ASSERT_EQ(res, CURLE_OK);
+  ASSERT_EQ(buffer, "Hello, World!");
 }
 
 TEST(http_client_test, basic_tls_request_with_auth_no_client_cert) {
@@ -155,12 +157,13 @@ TEST(http_client_test, basic_tls_request_with_auth_no_client_cert) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   res = curl_easy_perform(curl);
-  ASSERT_NE(res, CURLE_OK);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   server.shutdown();
+
+  ASSERT_NE(res, CURLE_OK);
 }
 
 TEST(http_client_test, basic_tls_request_with_auth_client_cert_not_signed) {
@@ -196,12 +199,13 @@ TEST(http_client_test, basic_tls_request_with_auth_client_cert_not_signed) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   res = curl_easy_perform(curl);
-  ASSERT_NE(res, CURLE_OK);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   server.shutdown();
+
+  ASSERT_NE(res, CURLE_OK);
 }
 
 static bool callback_called = false;
@@ -246,15 +250,16 @@ TEST(http_client_test, basic_tls_request_with_auth_with_cb) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   res = curl_easy_perform(curl);
-  ASSERT_EQ(res, CURLE_OK);
-  ASSERT_EQ(buffer, "Hello, World!");
-  ASSERT_EQ(callback_called, true);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  callback_called = false;
 
   server.shutdown();
+
+  ASSERT_EQ(res, CURLE_OK);
+  ASSERT_EQ(buffer, "Hello, World!");
+  ASSERT_EQ(callback_called, true);
+  callback_called = false;
 }
 
 TEST(http_client_test, basic_tls_request_with_servefile) {
@@ -291,14 +296,15 @@ TEST(http_client_test, basic_tls_request_with_servefile) {
 
   res = curl_easy_perform(curl);
 
-  if (res != CURLE_OK)
+  if (res != CURLE_OK) {
     std::cerr << errorstring.data() << std::endl;
-
-  ASSERT_EQ(res, CURLE_OK);
-  ASSERT_EQ(buffer.rfind("-----BEGIN CERTIFICATE-----", 0), 0);
+  }
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   server.shutdown();
+
+  ASSERT_EQ(res, CURLE_OK);
+  ASSERT_EQ(buffer.rfind("-----BEGIN CERTIFICATE-----", 0), 0u);
 }


### PR DESCRIPTION
1) Added additional check to `Listener::bind` to handle the case when socket creation is failed
2) Added more logs to debug flaky `http_server_test.multiple_client_with_requests_to_multithreaded_server` test
3) Improved https test and fixed warning