### PR TITLE
Code improvements in HTTP Parsers

### DIFF
--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -105,7 +105,7 @@ private:
   Queue<RequestData> requestsQueue;
 
   TimerPool timerPool_;
-  Private::Parser<Http::Response> parser;
+  ResponseParser parser;
 };
 
 class ConnectionPool {

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -12,6 +12,7 @@
 #include <unordered_map>
 
 #include <pistache/async.h>
+#include <pistache/http.h>
 #include <pistache/net.h>
 #include <pistache/os.h>
 #include <pistache/stream.h>
@@ -23,11 +24,6 @@
 #endif /* PISTACHE_USE_SSL */
 
 namespace Pistache {
-namespace Http {
-namespace Private {
-class ParserBase;
-}
-} // namespace Http
 namespace Tcp {
 
 class Transport;
@@ -47,12 +43,9 @@ public:
 
   void *ssl() const;
 
-  void putData(std::string name,
-               std::shared_ptr<Pistache::Http::Private::ParserBase> data);
-  std::shared_ptr<Pistache::Http::Private::ParserBase>
-  getData(std::string name) const;
-  std::shared_ptr<Pistache::Http::Private::ParserBase>
-  tryGetData(std::string name) const;
+  void putData(std::string name, std::shared_ptr<Http::Parser> data);
+  std::shared_ptr<Http::Parser> getData(std::string name) const;
+  std::shared_ptr<Http::Parser> tryGetData(std::string name) const;
 
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
 
@@ -68,9 +61,7 @@ private:
   Address addr;
 
   std::string hostname_;
-  std::unordered_map<std::string,
-                     std::shared_ptr<Pistache::Http::Private::ParserBase>>
-      data_;
+  std::unordered_map<std::string, std::shared_ptr<Http::Parser>> data_;
 
   void *ssl_ = nullptr;
 };

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -75,8 +75,7 @@ int Peer::fd() const {
   return fd_;
 }
 
-void Peer::putData(std::string name,
-                   std::shared_ptr<Pistache::Http::Private::ParserBase> data) {
+void Peer::putData(std::string name, std::shared_ptr<Http::Parser> data) {
   auto it = data_.find(name);
   if (it != std::end(data_)) {
     throw std::runtime_error("The data already exists");
@@ -85,8 +84,7 @@ void Peer::putData(std::string name,
   data_.insert(std::make_pair(std::move(name), std::move(data)));
 }
 
-std::shared_ptr<Pistache::Http::Private::ParserBase>
-Peer::getData(std::string name) const {
+std::shared_ptr<Http::Parser> Peer::getData(std::string name) const {
   auto data = tryGetData(std::move(name));
   if (data == nullptr) {
     throw std::runtime_error("The data does not exist");
@@ -95,8 +93,7 @@ Peer::getData(std::string name) const {
   return data;
 }
 
-std::shared_ptr<Pistache::Http::Private::ParserBase>
-Peer::tryGetData(std::string(name)) const {
+std::shared_ptr<Http::Parser> Peer::tryGetData(std::string(name)) const {
   auto it = data_.find(name);
   if (it == std::end(data_))
     return nullptr;

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -8,6 +8,7 @@
 
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
+#include <pistache/peer.h>
 #include <pistache/router.h>
 
 #include "httplib.h"


### PR DESCRIPTION
I'm proposing the following code improvements:

1) Introduced in `Http` namespace correspondent parser classes `Parser`, `RequestParser`, `ResponseParser` instead of using entities from `Private` namespace in different parts of code;
2) Removed several `friend` relationships between classes;
3) Added a unit test for checking parser reset.

It looks that code compatibitily shouldn't be broken after these changes, but it would be better to double check it.