### PR TITLE
optional: make Some and None constructors implicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if (PISTACHE_BUILD_TESTS)
                 "-DCPPCHECK"
                 "--suppress=*:${PROJECT_SOURCE_DIR}/third-party*"
                 "--suppress=*:${PROJECT_SOURCE_DIR}/tests*"
+                "--suppress=noExplicitConstructor:include/pistache/optional.h"
         )
     else()
         message("-- Cppcheck not found")

--- a/include/pistache/optional.h
+++ b/include/pistache/optional.h
@@ -125,12 +125,12 @@ public:
   }
 
   template <typename U>
-  explicit Optional(types::Some<U> some) : none_flag(NoneMarker) {
+  Optional(types::Some<U> some) : none_flag(NoneMarker) {
     static_assert(std::is_same<T, U>::value || std::is_convertible<U, T>::value,
                   "Types mismatch");
     from_some_helper(std::move(some), types::is_move_constructible<U>());
   }
-  explicit Optional(types::None) { none_flag = NoneMarker; }
+  Optional(types::None) { none_flag = NoneMarker; }
 
   template <typename U> Optional<T> &operator=(types::Some<U> some) {
     static_assert(std::is_same<T, U>::value || std::is_convertible<U, T>::value,

--- a/tests/optional_test.cc
+++ b/tests/optional_test.cc
@@ -99,7 +99,7 @@ TEST(optional, copy_assignment_operator_none) {
   Optional<bool> value(Pistache::None());
   EXPECT_TRUE(value.isEmpty());
 
-  Optional<bool> assigned = Pistache::Optional<bool>(Pistache::None());
+  Optional<bool> assigned = Pistache::None();
   EXPECT_TRUE(assigned.isEmpty());
 }
 


### PR DESCRIPTION
Related to #658 

I know cppcheck is a nice tool, but it's wrong in this specific case - not all constructors should be explicit.
`Pistache::Some` and `Pistache::None` are helper functions which allow to create an optional value.
But if our constructors have to be always explicit then what's the need for these functions?
We could just create a marker like `Pistache::Nullopt` and get rid of these two, if we want to have everything explicit (which doesn't really make sense, since you should be able to do an assigment).

#658 has blocked following syntax
```
Pistache::Optional<int> value = Pistache::Some(10);
```

now we need to do
```
Pistache::Optional<int> value = Pistache::Optional<int>(Pistache::Some(10));
```

which is inefficient, of course we could shorten it by using `auto`
```
auto value = Pistache::Optional<int>(Pistache::Some(10));
```

but problem is, that using `auto` we can use the first syntax too and we've just lost control over our types
```
auto value = Pistache::Some(10);
```

Anyways, I've went with approach to revert changes related to Pistache::Some/Pistache::None and I've added a suppression to CMakeLists.txt, so cppcheck always ignores implicit constructors in `optional.h`