### PR TITLE
Make onInput private in Http handler

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -568,9 +568,6 @@ using ResponseParser = Private::ParserImpl<Http::Response>;
 
 class Handler : public Tcp::Handler {
 public:
-  void onInput(const char *buffer, size_t len,
-               const std::shared_ptr<Tcp::Peer> &peer) override;
-
   void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
   void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override;
 
@@ -586,6 +583,8 @@ public:
   virtual ~Handler() override {}
 
 private:
+  void onInput(const char *buffer, size_t len,
+               const std::shared_ptr<Tcp::Peer> &peer) override;
   RequestParser &getParser(const std::shared_ptr<Tcp::Peer> &peer) const;
 
 private:


### PR DESCRIPTION
I my opinion, `onInput` method must be `private` in Http `Handler`.
For instance, now, it's possible for Pistache user to override this method:
```
class CustomHandler : public Http::Handler {
public:
    HTTP_PROTOTYPE(CustomHandler)
...
    void onInput(const char *buffer, size_t len,
                         const std::shared_ptr<Tcp::Peer> &peer) override;
...
```
and as a result everything will be broken. `onInput` method is part of implementation and shouldn't be exposed for user.
