### PR TITLE
Changes in Http: make onConnection and onDisconnection methods private

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -26,7 +26,6 @@
 #include <pistache/stream.h>
 #include <pistache/tcp.h>
 #include <pistache/transport.h>
-#include <pistache/view.h>
 
 namespace Pistache {
 namespace Tcp {
@@ -568,9 +567,6 @@ using ResponseParser = Private::ParserImpl<Http::Response>;
 
 class Handler : public Tcp::Handler {
 public:
-  void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
-  void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override;
-
   virtual void onRequest(const Request &request, ResponseWriter response) = 0;
 
   virtual void onTimeout(const Request &request, ResponseWriter response);
@@ -583,6 +579,8 @@ public:
   virtual ~Handler() override {}
 
 private:
+  void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
+  void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override;
   void onInput(const char *buffer, size_t len,
                const std::shared_ptr<Tcp::Peer> &peer) override;
   RequestParser &getParser(const std::shared_ptr<Tcp::Peer> &peer) const;
@@ -603,11 +601,5 @@ std::shared_ptr<H> make_handler(Args &&... args) {
   return std::make_shared<H>(std::forward<Args>(args)...);
 }
 
-namespace helpers {
-inline Address httpAddr(const StringView &view) {
-  auto const str = view.toString();
-  return Address(str);
-}
-} // namespace helpers
 } // namespace Http
 } // namespace Pistache

--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <pistache/view.h>
+
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -153,6 +155,13 @@ private:
   IP ip_;
   Port port_;
 };
+
+namespace helpers {
+inline Address httpAddr(const StringView &view) {
+  auto const str = view.toString();
+  return Address(str);
+}
+} // namespace helpers
 
 class Error : public std::runtime_error {
 public:


### PR DESCRIPTION
Hello,

I have read [Http Handler](http://pistache.io/guide/#http-handler) part of Pistache user guide and understood that `onConnection` and `onDisconnection` methods are not part of public API. `onConnection` method is part of implementation:
```
void Handler::onConnection(const std::shared_ptr<Tcp::Peer> &peer) {
  peer->putData(ParserData, std::make_shared<RequestParser>(maxRequestSize_));
}
```
That's why they must be `private` and client shouldn't have permissions to use them. Moreover, there are plenty of internal details that can be access by client in Peer object.

Also I'm proposing to move `httpAddr` to `net.h`. I think it's better place for this code.