### PR TITLE
Add -Wconversion compilation flag and fix related warnings (originated by #733)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (pistache)
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-missing-field-initializers")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/examples/http_server.cc
+++ b/examples/http_server.cc
@@ -157,10 +157,10 @@ int main(int argc, char *argv[]) {
     int thr = 2;
 
     if (argc >= 2) {
-        port = std::stol(argv[1]);
+        port = static_cast<uint16_t>(std::stol(argv[1]));
 
         if (argc == 3)
-            thr = std::stol(argv[2]);
+            thr = std::stoi(argv[2]);
     }
 
     Address addr(Ipv4::any(), port);

--- a/examples/rest_description.cc
+++ b/examples/rest_description.cc
@@ -30,7 +30,7 @@ public:
 
     void init(size_t thr = 2) {
         auto opts = Http::Endpoint::options()
-            .threads(thr);
+            .threads(static_cast<int>(thr));
         httpEndpoint->init(opts);
         createDescription();
     }
@@ -137,10 +137,10 @@ int main(int argc, char *argv[]) {
     int thr = 2;
 
     if (argc >= 2) {
-        port = std::stol(argv[1]);
+        port = static_cast<uint16_t>(std::stol(argv[1]));
 
         if (argc == 3)
-            thr = std::stol(argv[2]);
+            thr = std::stoi(argv[2]);
     }
 
     Address addr(Ipv4::any(), port);

--- a/examples/rest_server.cc
+++ b/examples/rest_server.cc
@@ -39,7 +39,7 @@ public:
 
     void init(size_t thr = 2) {
         auto opts = Http::Endpoint::options()
-            .threads(thr);
+            .threads(static_cast<int>(thr));
         httpEndpoint->init(opts);
         setupRoutes();
     }
@@ -150,10 +150,10 @@ int main(int argc, char *argv[]) {
     int thr = 2;
 
     if (argc >= 2) {
-        port = std::stol(argv[1]);
+        port = static_cast<uint16_t>(std::stol(argv[1]));
 
         if (argc == 3)
-            thr = std::stol(argv[2]);
+            thr = std::stoi(argv[2]);
     }
 
     Address addr(Ipv4::any(), port);

--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -24,7 +24,7 @@
       std::ostringstream oss;                                                  \
       oss << str << ": ";                                                      \
       if (errno == 0) {                                                        \
-        oss << gai_strerror(ret);                                              \
+        oss << gai_strerror(static_cast<int>(ret));                                              \
       } else {                                                                 \
         oss << strerror(errno);                                                \
       }                                                                        \

--- a/include/pistache/date.h
+++ b/include/pistache/date.h
@@ -4832,7 +4832,7 @@ void read(std::basic_istream<CharT, Traits> &is, int a0, Args &&... args) {
     CharT buf[std::numeric_limits<unsigned>::digits10 + 2] = {};
     auto e = buf;
     do {
-      *e++ = CharT(u % 10) + CharT{'0'};
+      *e++ = static_cast<CharT>((u % 10) + '0');
       u /= 10;
     } while (u > 0);
     std::reverse(buf, e);
@@ -4915,7 +4915,7 @@ from_stream(std::basic_istream<CharT, Traits> &is, const CharT *fmt,
           auto nm = detail::weekday_names();
           auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
           if (!is.fail())
-            wd = i % 7;
+            wd = static_cast<int>(i % 7);
 #endif
           command = nullptr;
           width = -1;
@@ -4937,7 +4937,7 @@ from_stream(std::basic_istream<CharT, Traits> &is, const CharT *fmt,
           auto nm = detail::month_names();
           auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
           if (!is.fail())
-            m = i % 12 + 1;
+            m = static_cast<int>(i % 12 + 1);
 #endif
           command = nullptr;
           width = -1;
@@ -4964,13 +4964,13 @@ from_stream(std::basic_istream<CharT, Traits> &is, const CharT *fmt,
           auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
           if (is.fail())
             goto broken;
-          wd = i % 7;
+          wd = static_cast<int>(i % 7);
           ws(is);
           nm = detail::month_names();
           i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
           if (is.fail())
             goto broken;
-          m = i % 12 + 1;
+          m = static_cast<int>(i % 12 + 1);
           ws(is);
           read(is, rs{d, 1, 2});
           if (is.fail())

--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -187,7 +187,7 @@ private:
 
 public:
   string_view::size_type operator()(const string_view &str) const {
-    const size_t len = str.length();
+    const uint32_t len = static_cast<uint32_t>(str.length());
     const uint8_t *data = reinterpret_cast<const uint8_t *>(str.data());
     const int nblocks = static_cast<int>(len / 4);
 

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -337,7 +337,7 @@ void Transport::handleReadableEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isReadable() && "Entry must be readable");
 
   auto tag = entry.getTag();
-  const Fd fd = tag.value();
+  auto fd = static_cast<const Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto connection = connIt->second.connection.lock();
@@ -364,7 +364,7 @@ void Transport::handleWritableEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isWritable() && "Entry must be writable");
 
   auto tag = entry.getTag();
-  const Fd fd = tag.value();
+  auto fd = static_cast<const Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto &connectionEntry = connIt->second;
@@ -385,7 +385,7 @@ void Transport::handleHangupEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isHangup() && "Entry must be hangup");
 
   auto tag = entry.getTag();
-  const Fd fd = tag.value();
+  auto fd = static_cast<const Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto &connectionEntry = connIt->second;

--- a/src/common/base64.cc
+++ b/src/common/base64.cc
@@ -81,15 +81,15 @@ const vector<byte> &Base64Decoder::Decode() {
   // While there is at least one set of three octets remaining to decode...
   for (string::size_type Index = 2; Index < DecodedSize; Index += 3) {
     // Construct octets from sextets...
-    m_DecodedData.at(OutputOffset + 0) =
+    m_DecodedData.at(OutputOffset + 0) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 0)) << 2 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4;
-    m_DecodedData.at(OutputOffset + 1) =
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4);
+    m_DecodedData.at(OutputOffset + 1) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) << 4 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 2)) >> 2;
-    m_DecodedData.at(OutputOffset + 2) =
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 2)) >> 2);
+    m_DecodedData.at(OutputOffset + 2) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 2)) << 6 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 3));
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 3)));
 
     // Reseek i/o pointers...
     InputOffset += 4;
@@ -100,19 +100,19 @@ const vector<byte> &Base64Decoder::Decode() {
   switch (DecodedSize % 3) {
   // One octet left to construct...
   case 1:
-    m_DecodedData.at(OutputOffset + 0) =
+    m_DecodedData.at(OutputOffset + 0) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 0)) << 2 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4;
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4);
     break;
 
   // Two octets left to construct...
   case 2:
-    m_DecodedData.at(OutputOffset + 0) =
+    m_DecodedData.at(OutputOffset + 0) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 0)) << 2 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4;
-    m_DecodedData.at(OutputOffset + 1) =
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) >> 4);
+    m_DecodedData.at(OutputOffset + 1) = static_cast<byte>(
         DecodeCharacter(m_Base64EncodedString.at(InputOffset + 1)) << 4 |
-        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 2)) >> 2;
+        DecodeCharacter(m_Base64EncodedString.at(InputOffset + 2)) >> 2);
     break;
   }
 
@@ -175,17 +175,17 @@ const string &Base64Encoder::Encode() noexcept {
   for (string::size_type Index = 0; Index < OctetTriplets; ++Index) {
     // Encode first sextet from first octet...
     m_Base64EncodedString.at(OutputOffset + 0) =
-        EncodeByte(m_InputBuffer.at(InputOffset + 0) >> 2);
+        EncodeByte(static_cast<byte>(m_InputBuffer.at(InputOffset + 0) >> 2));
 
     // Encode second sextet from first and second octet....
-    m_Base64EncodedString.at(OutputOffset + 1) = EncodeByte(
+    m_Base64EncodedString.at(OutputOffset + 1) = EncodeByte(static_cast<byte>(
         (m_InputBuffer.at(InputOffset + 0) & static_cast<byte>(0x03)) << 4 |
-        m_InputBuffer.at(InputOffset + 1) >> 4);
+        m_InputBuffer.at(InputOffset + 1) >> 4));
 
     // Encode third sextet from second and third octet...
-    m_Base64EncodedString.at(OutputOffset + 2) = EncodeByte(
+    m_Base64EncodedString.at(OutputOffset + 2) = EncodeByte(static_cast<byte>(
         (m_InputBuffer.at(InputOffset + 1) & static_cast<byte>(0x0F)) << 2 |
-        m_InputBuffer.at(InputOffset + 2) >> 6);
+        m_InputBuffer.at(InputOffset + 2) >> 6));
 
     // Encode fourth sextet from third octet...
     m_Base64EncodedString.at(OutputOffset + 3) =
@@ -205,7 +205,7 @@ const string &Base64Encoder::Encode() noexcept {
 
     // Encode first sextet from remaining octet...
     m_Base64EncodedString.at(OutputOffset + 0) =
-        EncodeByte(m_InputBuffer.at(InputOffset + 0) >> 2);
+        EncodeByte(static_cast<byte>(m_InputBuffer.at(InputOffset + 0) >> 2));
 
     // Encode second sextet from remaining octet and empty second one...
     m_Base64EncodedString.at(OutputOffset + 1) = EncodeByte(
@@ -222,12 +222,12 @@ const string &Base64Encoder::Encode() noexcept {
 
     // Encode first sextet from first octet...
     m_Base64EncodedString.at(OutputOffset + 0) =
-        EncodeByte(m_InputBuffer.at(InputOffset + 0) >> 2);
+        EncodeByte(static_cast<byte>(m_InputBuffer.at(InputOffset + 0) >> 2));
 
     // Encode second sextet from first and second octet...
-    m_Base64EncodedString.at(OutputOffset + 1) = EncodeByte(
+    m_Base64EncodedString.at(OutputOffset + 1) = EncodeByte(static_cast<byte>(
         (m_InputBuffer.at(InputOffset + 0) & static_cast<byte>(0x03)) << 4 |
-        m_InputBuffer.at(InputOffset + 1) >> 4);
+        m_InputBuffer.at(InputOffset + 1) >> 4));
 
     // Encode third sextet from second and dummy third octet...
     m_Base64EncodedString.at(OutputOffset + 2) = EncodeByte(
@@ -246,23 +246,24 @@ const string &Base64Encoder::Encode() noexcept {
 // Encode single binary byte to 6-bit base 64 character...
 inline unsigned char Base64Encoder::EncodeByte(const byte Byte) const {
   // Capital letter 'A' is ASCII 65 and zero in base 64...
-  if (static_cast<unsigned char>(Byte) < 26)
-    return static_cast<unsigned char>(Byte) + 'A';
+  auto ch = static_cast<unsigned char>(Byte);
+  if ( ch < 26)
+    return static_cast<unsigned char>(ch + 'A');
 
   // Lowercase letter 'a' is ASCII 97 and 26 in base 64...
-  if (static_cast<unsigned char>(Byte) < 52)
-    return static_cast<unsigned char>(Byte) + 71;
+  if (ch < 52)
+    return static_cast<unsigned char>(ch + 71);
 
   // Numeric digit '0' is ASCII 48 and 52 in base 64...
-  if (static_cast<unsigned char>(Byte) < 62)
-    return static_cast<unsigned char>(Byte) - 4;
+  if (ch < 62)
+    return static_cast<unsigned char>(ch - 4);
 
   // '+' is ASCII 43 and 62 in base 64...
-  if (static_cast<unsigned char>(Byte) == 62)
+  if (ch == 62)
     return '+';
 
   // '/' is ASCII 47 and 63 in base 64...
-  if (static_cast<unsigned char>(Byte) == 63)
+  if (ch == 63)
     return '/';
 
   // And lastly anything that can't be represented in 6-bits we return 64...

--- a/src/common/http_header.cc
+++ b/src/common/http_header.cc
@@ -138,7 +138,7 @@ void CacheControl::parseRaw(const char *str, size_t len) {
           // @Security: if str is not \0 terminated, there might be a situation
           // where strtol can overflow. Double-check that it's harmless and fix
           // if not
-          int secs = strtol(beg, &end, 10);
+          auto secs = strtol(beg, &end, 10);
           cursor.advance(end - beg);
           if (!cursor.eof() && cursor.current() != ',') {
             throw std::runtime_error(

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -258,7 +258,7 @@ Address::Address(IP ip, Port port) : ip_(ip), port_(port) {}
 Address Address::fromUnix(struct sockaddr *addr) {
   if ((addr->sa_family == AF_INET) or (addr->sa_family == AF_INET6)) {
     IP ip = IP(addr);
-    Port port = Port(ip.getPort());
+    Port port = Port(static_cast<uint16_t>(ip.getPort()));
     assert(addr);
     return Address(ip, port);
   }
@@ -324,7 +324,7 @@ void Address::init(const std::string &addr) {
     long port = strtol(portPart.c_str(), &end, 10);
     if (*end != 0 || port < Port::min() || port > Port::max())
       throw std::invalid_argument("Invalid port");
-    port_ = Port(port);
+    port_ = Port(static_cast<uint16_t>(port));
   }
 }
 

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -171,7 +171,7 @@ int Epoll::poll(std::vector<Event> &events,
 
   int ready_fds = -1;
   do {
-    ready_fds = ::epoll_wait(epoll_fd, evs, Const::MaxEvents, timeout.count());
+    ready_fds = ::epoll_wait(epoll_fd, evs, Const::MaxEvents, static_cast<int>(timeout.count()));
   } while (ready_fds < 0 && errno == EINTR);
 
   for (int i = 0; i < ready_fds; ++i) {

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -328,7 +328,7 @@ public:
 
       auto cl = handler->clone();
       auto key = wrk->sync->addHandler(cl, false /* setKey */);
-      auto newKey = encodeKey(key, i);
+      auto newKey = encodeKey(key, static_cast<uint32_t>(i));
       cl->key_ = newKey;
 
       keys.at(i) = key;
@@ -398,8 +398,8 @@ private:
   static std::pair<uint32_t, uint32_t>
   decodeKey(const Reactor::Key &encodedKey) {
     auto data = encodedKey.data();
-    uint32_t hi = data >> 32;
-    uint32_t lo = data & 0xFFFFFFFF;
+    auto hi = static_cast<uint32_t>(data >> 32);
+    auto lo = static_cast<uint32_t>(data & 0xFFFFFFFF);
     return std::make_pair(hi, lo);
   }
 

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -115,7 +115,7 @@ DynamicStreamBuf::overflow(DynamicStreamBuf::int_type ch) {
     const auto size = data_.size();
     if (size < maxSize_) {
       reserve((size ? size : 1u) * 2);
-      *pptr() = ch;
+      *pptr() = static_cast<char>(ch);
       pbump(1);
       return traits_type::not_eof(ch);
     }
@@ -156,7 +156,7 @@ int StreamCursor::next() const {
   return buf->snext();
 }
 
-char StreamCursor::current() const { return buf->sgetc(); }
+char StreamCursor::current() const { return static_cast<char>(buf->sgetc()); }
 
 const char *StreamCursor::offset() const { return buf->curptr(); }
 
@@ -201,8 +201,8 @@ bool match_string(const char *str, size_t len, StreamCursor &cursor,
   } else {
     const char *off = cursor.offset();
     for (size_t i = 0; i < len; ++i) {
-      const char lhs = std::tolower(str[i]);
-      const char rhs = std::tolower(off[i]);
+      const char lhs = static_cast<char>(std::tolower(str[i]));
+      const char rhs = static_cast<char>(std::tolower(off[i]));
       if (lhs != rhs)
         return false;
     }
@@ -218,10 +218,10 @@ bool match_literal(char c, StreamCursor &cursor, CaseSensitivity cs) {
   if (cursor.eof())
     return false;
 
-  char lhs = (cs == CaseSensitivity::Sensitive ? c : std::tolower(c));
+  char lhs = (cs == CaseSensitivity::Sensitive ? c : static_cast<char>(std::tolower(c)));
   char rhs =
       (cs == CaseSensitivity::Sensitive ? cursor.current()
-                                        : std::tolower(cursor.current()));
+                                        : static_cast<char>(std::tolower(cursor.current())));
 
   if (lhs == rhs) {
     cursor.advance(1);
@@ -242,8 +242,8 @@ bool match_until(std::initializer_list<char> chars, StreamCursor &cursor,
 
   auto find = [&](char val) {
     for (auto c : chars) {
-      char lhs = cs == CaseSensitivity::Sensitive ? c : std::tolower(c);
-      char rhs = cs == CaseSensitivity::Insensitive ? val : std::tolower(val);
+      char lhs = cs == CaseSensitivity::Sensitive ? c : static_cast<char>(std::tolower(c));
+      char rhs = cs == CaseSensitivity::Insensitive ? val : static_cast<char>(std::tolower(val));
 
       if (lhs == rhs)
         return true;

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -125,7 +125,7 @@ void Transport::handleIncoming(const std::shared_ptr<Peer> &peer) {
 #ifdef PISTACHE_USE_SSL
     if (peer->ssl() != NULL) {
       bytes = SSL_read((SSL *)peer->ssl(), buffer + totalBytes,
-                       Const::MaxBuffer - totalBytes);
+                       static_cast<int>(Const::MaxBuffer - totalBytes));
     } else {
 #endif /* PISTACHE_USE_SSL */
       bytes = recv(fd, buffer + totalBytes, Const::MaxBuffer - totalBytes, 0);
@@ -228,7 +228,7 @@ void Transport::asyncWriteImpl(Fd fd) {
 
         if (it_->second->ssl() != NULL) {
           auto ssl_ = static_cast<SSL *>(it_->second->ssl());
-          bytesWritten = SSL_write(ssl_, ptr, len);
+          bytesWritten = SSL_write(ssl_, ptr, static_cast<int>(len));
         } else {
 #endif /* PISTACHE_USE_SSL */
           bytesWritten = ::send(fd, ptr, len, flags);

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -28,7 +28,7 @@ ssize_t SSL_sendfile(SSL *out, int in, off_t *offset, size_t count) {
   if (ret == -1)
     return -1;
 
-  written = SSL_write(out, buffer, ret);
+  written = SSL_write(out, buffer, static_cast<int>(ret));
   if (offset != NULL)
     *offset += written;
 

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -273,8 +273,8 @@ Listener::requestLoad(const Listener::Load &old) {
             } else {
 
               auto totalElapsed = [](rusage usage) {
-                return (usage.ru_stime.tv_sec * 1e6 + usage.ru_stime.tv_usec) +
-                       (usage.ru_utime.tv_sec * 1e6 + usage.ru_utime.tv_usec);
+                return static_cast<double>((usage.ru_stime.tv_sec * 1000000 + usage.ru_stime.tv_usec) +
+                                           (usage.ru_utime.tv_sec * 1000000 + usage.ru_utime.tv_usec));
               };
 
               auto now = std::chrono::system_clock::now();
@@ -290,12 +290,12 @@ Listener::requestLoad(const Listener::Load &old) {
                 auto nowElapsed = totalElapsed(usage);
                 auto timeElapsed = nowElapsed - totalElapsed(last);
 
-                auto loadPct = (timeElapsed * 100.0) / tick.count();
+                auto loadPct = (timeElapsed * 100.0) / static_cast<double>(tick.count());
                 res.workers.push_back(loadPct);
                 res.global += loadPct;
               }
 
-              res.global /= usages.size();
+              res.global /= static_cast<double>(usages.size());
             }
 
             return res;

--- a/tests/async_test.cc
+++ b/tests/async_test.cc
@@ -433,7 +433,7 @@ TEST(async_test, stress_multithreaded_test) {
 
   for (size_t i = 0; i < Ops; ++i) {
     auto &wrk = workers[wrkIndex];
-    wrk->doWork(i).then(
+    wrk->doWork(static_cast<int>(i)).then(
         [&](int seq) {
           UNUSED(seq)
           ++resolved;

--- a/tests/httplib.h
+++ b/tests/httplib.h
@@ -957,26 +957,26 @@ inline size_t to_utf8(int code, char* buff)
         buff[0] = (code & 0x7F);
         return 1;
     } else if (code < 0x0800) {
-        buff[0] = (0xC0 | ((code >> 6) & 0x1F));
-        buff[1] = (0x80 | (code & 0x3F));
+        buff[0] = static_cast<char>(0xC0 | ((code >> 6) & 0x1F));
+        buff[1] = static_cast<char>(0x80 | (code & 0x3F));
         return 2;
     } else if (code < 0xD800) {
-        buff[0] = (0xE0 | ((code >> 12) & 0xF));
-        buff[1] = (0x80 | ((code >> 6) & 0x3F));
-        buff[2] = (0x80 | (code & 0x3F));
+        buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+        buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+        buff[2] = static_cast<char>(0x80 | (code & 0x3F));
         return 3;
     } else if (code < 0xE000)  { // D800 - DFFF is invalid...
         return 0;
     } else if (code < 0x10000) {
-        buff[0] = (0xE0 | ((code >> 12) & 0xF));
-        buff[1] = (0x80 | ((code >> 6) & 0x3F));
-        buff[2] = (0x80 | (code & 0x3F));
+        buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+        buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+        buff[2] = static_cast<char>(0x80 | (code & 0x3F));
         return 3;
     } else if (code < 0x110000) {
-        buff[0] = (0xF0 | ((code >> 18) & 0x7));
-        buff[1] = (0x80 | ((code >> 12) & 0x3F));
-        buff[2] = (0x80 | ((code >> 6) & 0x3F));
-        buff[3] = (0x80 | (code & 0x3F));
+        buff[0] = static_cast<char>(0xF0 | ((code >> 18) & 0x7));
+        buff[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
+        buff[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+        buff[3] = static_cast<char>(0x80 | (code & 0x3F));
         return 4;
     }
 
@@ -1007,7 +1007,7 @@ inline std::string decode_url(const std::string& s)
                 int val = 0;
                 if (from_hex_to_i(s, i + 1, 2, val)) {
                     // 2 digits hex codes
-                    result += val;
+                    result += static_cast<char>(val);
                     i += 2; // '00'
                 } else {
                     result += s[i];
@@ -1140,7 +1140,7 @@ inline std::string to_lower(const char* beg, const char* end)
     std::string out;
     auto it = beg;
     while (it != end) {
-        out += ::tolower(*it);
+        out += static_cast<char>(::tolower(*it));
         it++;
     }
     return out;
@@ -1391,12 +1391,12 @@ inline SocketStream::~SocketStream()
 
 inline int SocketStream::read(char* ptr, size_t size)
 {
-    return recv(sock_, ptr, size, 0);
+    return static_cast<int>(recv(sock_, ptr, size, 0));
 }
 
 inline int SocketStream::write(const char* ptr, size_t size)
 {
-    return send(sock_, ptr, size, 0);
+    return static_cast<int>(send(sock_, ptr, size, 0));
 }
 
 inline int SocketStream::write(const char* ptr)

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -22,7 +22,7 @@ public:
       : httpEndpoint(std::make_shared<Http::Endpoint>(addr)) {}
 
   void init(size_t thr = 2) {
-    auto opts = Http::Endpoint::options().threads(thr);
+    auto opts = Http::Endpoint::options().threads(static_cast<int>(thr));
     httpEndpoint->init(opts);
     setupRoutes();
   }

--- a/tests/streaming_test.cc
+++ b/tests/streaming_test.cc
@@ -63,7 +63,7 @@ void dumpData(const Rest::Request & /*req*/, Http::ResponseWriter response) {
       auto job = [&stream, &responseLock, i]() -> void {
         constexpr size_t nchunks = 10;
         constexpr size_t chunk_size = LETTER_REPEATS / nchunks;
-        const std::string payload(chunk_size, letter + i);
+        const std::string payload(chunk_size, static_cast<char>(letter + i));
         {
           Guard guard(responseLock);
           for (size_t chunk = 0; chunk < nchunks; ++chunk) {


### PR DESCRIPTION
Add `-Wconversion` compilation flag and fix related warnings, mainly by adding `static_cast` in problematic locations.

After this PR, there are still quite a few type conversion warnings remain:
1. `async.h:465` - deep template parameters usage, I could not find a good cast
2. `date.h:1641`, `:1642` - I could not find a good way to cast to a bit field
3. A lot of `-Wconversion` warnings appear when compiling RapidJson library. Not fixed in this PR
