### PR TITLE
Fix -wConversion warnings #748

### DIFF
--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -794,7 +794,7 @@ Async::Promise<ssize_t> ResponseWriter::putOnWire(const char *data,
     auto fd = peer()->fd();
 
     return transport_->asyncWrite(fd, buffer)
-        .then<std::function<Async::Promise<ssize_t>(int)>,
+        .then<std::function<Async::Promise<ssize_t>(ssize_t)>,
               std::function<void(std::exception_ptr &)>>(
             [=](int /*l*/) {
               return Async::Promise<ssize_t>([=](

--- a/src/common/http_defs.cc
+++ b/src/common/http_defs.cc
@@ -8,7 +8,14 @@
 #include <iostream>
 
 #include <pistache/common.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
 #include <pistache/date.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #include <pistache/http_defs.h>
 
 namespace Pistache {


### PR DESCRIPTION
Fix warnings occurring in gcc, described in #748