### PR TITLE
Fix shutdown data race in listner.cc

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -204,7 +204,8 @@ Port Listener::getPort() const {
 }
 
 void Listener::run() {
-  shutdownFd.bind(poller);
+  if (!shutdownFd.isBound())
+    shutdownFd.bind(poller);
   reactor_.run();
 
   for (;;) {
@@ -236,6 +237,7 @@ void Listener::run() {
 }
 
 void Listener::runThreaded() {
+  shutdownFd.bind(poller);
   acceptThread = std::thread([=]() { this->run(); });
 }
 


### PR DESCRIPTION
A race exists between the runThreaded and shutdown/dtor as follows:

 runThreaded - called
 shutdown - called
 shutdown - check for shutdownFd.isBound returns false (so no notify)
 runThreaded - thread executing 'run' starts
 runThreaded - thread calls shutdownFd.bind
 shutdown - blocks waiting for run thread
 runThreaded - continues to run as no notification received

This deadlock avoided by ensuring the shutdownFd.bind is called before
the thread is created rather than doing it at the start of the thread's
execution.