### PR TITLE
Fixing broken TravisCI builds for the clang toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-bionic-4.0']
         packages: [ 'apport', 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   - os: linux
@@ -35,7 +35,7 @@ matrix:
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-bionic-5.0']
         packages: [ 'apport', 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   - os: linux
@@ -46,7 +46,7 @@ matrix:
       - COV_TOOL_ARGS=gcov
     addons:
       apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-bionic-6.0']
         packages: [ 'apport', 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov', 'cppcheck' ]
 
   # Linux GCC builds


### PR DESCRIPTION
I saw your comment on #762 regarding failing Travis builds and I tried to solve it.
Seems like the issue is that you were loading a `trusty` clang pipeline, which is for Ubuntu 14.04 LTS but at the top of the travis.yml you specify `bionic` which is Ubuntu 18.04 LTS, so I fixed the clang pipeline to use `bionic` too.

This issue seems the same that a guy was reporting here: https://travis-ci.community/t/cannot-apt-get-install-clang-5-0/3250/3
That time (1 year ago) the suggestion was to switch from `trusty` to `xenial` (Ubuntu 16.04 LTS) or, in alternative, to add `dist: trusty` at the top of the file to keep using `trusty` but, since you are already using `bionic`, this suggest didn't seem to fit in your build system.