### PR TITLE
RaspberryPi4 Mobel B linker fix #762

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ if (PISTACHE_USE_SSL)
     link_libraries(-lssl -lcrypto)
 endif (PISTACHE_USE_SSL)
 
+link_libraries(-latomic)
 include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Set version...
@@ -113,7 +114,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Set libraries...
 
     # Minimum...
-    set(LIBS "-lpistache -lpthread")
+    set(LIBS "-lpistache -lpthread -latomic")
 
     # If building with OpenSSL support...
     if(PISTACHE_USE_SSL)


### PR DESCRIPTION
Hi,

Here is the patch for RaspberryPi 4 discussed in #762.
Below I'm attaching a build log. I ran the tests too, everything seems alright but I couldn't get memory check to work property using valgrind. It was taking so long with the first test that I just aborted it after 20 minutes :) I think the raspberrypi is too small to run such kind of tests.
[build.log](https://github.com/oktal/pistache/files/4617836/build.log)

Also, I had a look at adding a TravisCI profile to build raspberrypi-compatible binaries but it's non trivial unfortunately because RaspberryPi runs on ARM architecture. One way is to emulate ARM using QEMU on a x86 processor, this will make the build reaaaally slow though (https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html).
Then I found out that TravisCI now supports ARM natively, but the feature is still in alpha: https://docs.travis-ci.com/user/multi-cpu-architectures. 
I will have a play when I have some time and see if I can get it to work for my project on the raspberrypi. If I do, I will submit another pull request here for that too ;)

Fixes #762 