### PR TITLE
Logging api - addresses issue #771

### DIFF
--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -28,6 +28,7 @@ public:
     Options &backlog(int val);
     Options &maxRequestSize(size_t val);
     Options &maxResponseSize(size_t val);
+    Options &logger(PISTACHE_LOGGER_T logger);
 
     [[deprecated("Replaced by maxRequestSize(val)")]] Options &
     maxPayload(size_t val);
@@ -39,6 +40,7 @@ public:
     int backlog_;
     size_t maxRequestSize_;
     size_t maxResponseSize_;
+    PISTACHE_LOGGER_T logger_;
     Options();
   };
   Endpoint();
@@ -151,6 +153,7 @@ private:
   Tcp::Listener listener;
   size_t maxRequestSize_ = Const::DefaultMaxRequestSize;
   size_t maxResponseSize_ = Const::DefaultMaxResponseSize;
+  PISTACHE_LOGGER_T logger_ = PISTACHE_NULL_LOGGER;
 };
 
 template <typename Handler>

--- a/include/pistache/endpoint.h
+++ b/include/pistache/endpoint.h
@@ -28,7 +28,7 @@ public:
     Options &backlog(int val);
     Options &maxRequestSize(size_t val);
     Options &maxResponseSize(size_t val);
-    Options &logger(PISTACHE_LOGGER_T logger);
+    Options &logger(PISTACHE_STRING_LOGGER_T logger);
 
     [[deprecated("Replaced by maxRequestSize(val)")]] Options &
     maxPayload(size_t val);
@@ -40,7 +40,7 @@ public:
     int backlog_;
     size_t maxRequestSize_;
     size_t maxResponseSize_;
-    PISTACHE_LOGGER_T logger_;
+    PISTACHE_STRING_LOGGER_T logger_;
     Options();
   };
   Endpoint();
@@ -153,7 +153,7 @@ private:
   Tcp::Listener listener;
   size_t maxRequestSize_ = Const::DefaultMaxRequestSize;
   size_t maxResponseSize_ = Const::DefaultMaxResponseSize;
-  PISTACHE_LOGGER_T logger_ = PISTACHE_NULL_LOGGER;
+  PISTACHE_STRING_LOGGER_T logger_ = PISTACHE_NULL_STRING_LOGGER;
 };
 
 template <typename Handler>

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -9,6 +9,7 @@
 #include <pistache/async.h>
 #include <pistache/config.h>
 #include <pistache/flags.h>
+#include <pistache/log.h>
 #include <pistache/net.h>
 #include <pistache/os.h>
 #include <pistache/reactor.h>
@@ -51,7 +52,8 @@ public:
   void init(size_t workers,
             Flags<Options> options = Flags<Options>(Options::None),
             const std::string &workersName = "",
-            int backlog = Const::MaxBacklog);
+            int backlog = Const::MaxBacklog,
+            PISTACHE_LOGGER_T logger = PISTACHE_NULL_LOGGER);
   void setHandler(const std::shared_ptr<Handler> &handler);
 
   void bind();
@@ -100,6 +102,8 @@ private:
 
   bool useSSL_ = false;
   ssl::SSLCtxPtr ssl_ctx_ = nullptr;
+
+  PISTACHE_LOGGER_T logger_ = PISTACHE_NULL_LOGGER;
 };
 
 } // namespace Tcp

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -53,7 +53,7 @@ public:
             Flags<Options> options = Flags<Options>(Options::None),
             const std::string &workersName = "",
             int backlog = Const::MaxBacklog,
-            PISTACHE_LOGGER_T logger = PISTACHE_NULL_LOGGER);
+            PISTACHE_STRING_LOGGER_T logger = PISTACHE_NULL_STRING_LOGGER);
   void setHandler(const std::shared_ptr<Handler> &handler);
 
   void bind();
@@ -103,7 +103,7 @@ private:
   bool useSSL_ = false;
   ssl::SSLCtxPtr ssl_ctx_ = nullptr;
 
-  PISTACHE_LOGGER_T logger_ = PISTACHE_NULL_LOGGER;
+  PISTACHE_STRING_LOGGER_T logger_ = PISTACHE_NULL_STRING_LOGGER;
 };
 
 } // namespace Tcp

--- a/include/pistache/log.h
+++ b/include/pistache/log.h
@@ -1,0 +1,60 @@
+/* log.h
+   Michael Ellison, 27 May 2020
+
+   Logging API definitions
+*/
+
+#pragma once
+
+#include <memory>
+#include <sstream>
+
+namespace Pistache {
+namespace Log {
+
+enum class Level {
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+  FATAL
+};
+
+class LogHandler {
+public:
+  virtual void log(Level level, const std::string &message) = 0;
+  virtual bool isEnabledFor(Level level) const = 0;
+
+  virtual ~LogHandler() {}
+};
+
+class DefaultLogHandler : public LogHandler {
+public:
+  explicit DefaultLogHandler(Level level) : level_(level) {}
+  ~DefaultLogHandler() override {}
+
+  void log(Level level, const std::string &message) override;
+  bool isEnabledFor(Level level) const override;
+private:
+  Level level_;
+};
+
+} // namespace Log
+} // namespace Pistache
+
+#ifndef PISTACHE_LOG
+#define PISTACHE_LOG(level, logger_ptr, message) do {\
+  if (logger_ptr && logger_ptr->isEnabledFor(::Pistache::Log::Level::level)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger_ptr->log(::Pistache::Log::Level::level, oss_.str()); \
+  } \
+} while (0)
+#endif
+
+#ifndef DECLARE_PISTACHE_LOGGER
+#define DECLARE_PISTACHE_LOGGER(logger_ptr) \
+  std::unique_ptr<::Pistache::Log::LogHandler> logger_ptr
+#endif
+

--- a/include/pistache/log.h
+++ b/include/pistache/log.h
@@ -43,18 +43,88 @@ private:
 } // namespace Log
 } // namespace Pistache
 
-#ifndef PISTACHE_LOG
-#define PISTACHE_LOG(level, logger_ptr, message) do {\
-  if (logger_ptr && logger_ptr->isEnabledFor(::Pistache::Log::Level::level)) { \
+#ifndef PISTACHE_LOG_FATAL
+#define PISTACHE_LOG_FATAL(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::FATAL)) { \
     std::ostringstream oss_; \
     oss_ << message; \
-    logger_ptr->log(::Pistache::Log::Level::level, oss_.str()); \
+    logger->log(::Pistache::Log::Level::FATAL, oss_.str()); \
   } \
 } while (0)
 #endif
 
-#ifndef DECLARE_PISTACHE_LOGGER
-#define DECLARE_PISTACHE_LOGGER(logger_ptr) \
-  std::unique_ptr<::Pistache::Log::LogHandler> logger_ptr
+#ifndef PISTACHE_LOG_ERROR
+#define PISTACHE_LOG_ERROR(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::ERROR)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::ERROR, oss_.str()); \
+  } \
+} while (0)
+#endif
+
+#ifndef PISTACHE_LOG_WARN
+#define PISTACHE_LOG_WARN(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::WARN)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::WARN, oss_.str()); \
+  } \
+} while (0)
+#endif
+
+#ifndef PISTACHE_LOG_INFO
+#define PISTACHE_LOG_INFO(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::INFO)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::INFO, oss_.str()); \
+  } \
+} while (0)
+#endif
+
+#ifndef PISTACHE_LOG_DEBUG
+#define PISTACHE_LOG_DEBUG(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::DEBUG)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::DEBUG, oss_.str()); \
+  } \
+} while (0)
+#endif
+
+#ifndef PISTACHE_LOG_TRACE
+#ifndef NDEBUG // Only enable trace logging in debug builds.
+#define PISTACHE_LOG_TRACE(logger, message) do {\
+  if (logger && logger->isEnabledFor(::Pistache::Log::Level::TRACE)) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::TRACE, oss_.str()); \
+  } \
+} while (0)
+#else
+#define PISTACHE_LOG_TRACE(logger, message) do {\
+  if (0) { \
+    std::ostringstream oss_; \
+    oss_ << message; \
+    logger->log(::Pistache::Log::Level::TRACE, oss_.str()); \
+  } \
+} while (0)
+#endif
+#endif
+
+#ifndef PISTACHE_LOGGER_T
+#define PISTACHE_LOGGER_T \
+  std::shared_ptr<::Pistache::Log::LogHandler>
+#endif
+
+#ifndef PISTACHE_DEFAULT_LOGGER
+#define PISTACHE_DEFAULT_LOGGER \
+  std::make_shared<::Pistache::Log::DefaultLogHandler>(::Pistache::Log::Level::WARN)
+#endif
+
+#ifndef PISTACHE_NULL_LOGGER
+#define PISTACHE_NULL_LOGGER \
+  nullptr
 #endif
 

--- a/include/pistache/log.h
+++ b/include/pistache/log.h
@@ -21,18 +21,18 @@ enum class Level {
   FATAL
 };
 
-class LogHandler {
+class StringLogger {
 public:
   virtual void log(Level level, const std::string &message) = 0;
   virtual bool isEnabledFor(Level level) const = 0;
 
-  virtual ~LogHandler() {}
+  virtual ~StringLogger() {}
 };
 
-class DefaultLogHandler : public LogHandler {
+class DefaultStringLogger : public StringLogger {
 public:
-  explicit DefaultLogHandler(Level level) : level_(level) {}
-  ~DefaultLogHandler() override {}
+  explicit DefaultStringLogger(Level level) : level_(level) {}
+  ~DefaultStringLogger() override {}
 
   void log(Level level, const std::string &message) override;
   bool isEnabledFor(Level level) const override;
@@ -43,8 +43,8 @@ private:
 } // namespace Log
 } // namespace Pistache
 
-#ifndef PISTACHE_LOG_FATAL
-#define PISTACHE_LOG_FATAL(logger, message) do {\
+#ifndef PISTACHE_LOG_STRING_FATAL
+#define PISTACHE_LOG_STRING_FATAL(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::FATAL)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -53,8 +53,8 @@ private:
 } while (0)
 #endif
 
-#ifndef PISTACHE_LOG_ERROR
-#define PISTACHE_LOG_ERROR(logger, message) do {\
+#ifndef PISTACHE_LOG_STRING_ERROR
+#define PISTACHE_LOG_STRING_ERROR(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::ERROR)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -63,8 +63,8 @@ private:
 } while (0)
 #endif
 
-#ifndef PISTACHE_LOG_WARN
-#define PISTACHE_LOG_WARN(logger, message) do {\
+#ifndef PISTACHE_LOG_STRING_WARN
+#define PISTACHE_LOG_STRING_WARN(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::WARN)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -73,8 +73,8 @@ private:
 } while (0)
 #endif
 
-#ifndef PISTACHE_LOG_INFO
-#define PISTACHE_LOG_INFO(logger, message) do {\
+#ifndef PISTACHE_LOG_STRING_INFO
+#define PISTACHE_LOG_STRING_INFO(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::INFO)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -83,8 +83,8 @@ private:
 } while (0)
 #endif
 
-#ifndef PISTACHE_LOG_DEBUG
-#define PISTACHE_LOG_DEBUG(logger, message) do {\
+#ifndef PISTACHE_LOG_STRING_DEBUG
+#define PISTACHE_LOG_STRING_DEBUG(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::DEBUG)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -93,9 +93,9 @@ private:
 } while (0)
 #endif
 
-#ifndef PISTACHE_LOG_TRACE
+#ifndef PISTACHE_LOG_STRING_TRACE
 #ifndef NDEBUG // Only enable trace logging in debug builds.
-#define PISTACHE_LOG_TRACE(logger, message) do {\
+#define PISTACHE_LOG_STRING_TRACE(logger, message) do {\
   if (logger && logger->isEnabledFor(::Pistache::Log::Level::TRACE)) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -103,7 +103,7 @@ private:
   } \
 } while (0)
 #else
-#define PISTACHE_LOG_TRACE(logger, message) do {\
+#define PISTACHE_LOG_STRING_TRACE(logger, message) do {\
   if (0) { \
     std::ostringstream oss_; \
     oss_ << message; \
@@ -113,18 +113,18 @@ private:
 #endif
 #endif
 
-#ifndef PISTACHE_LOGGER_T
-#define PISTACHE_LOGGER_T \
-  std::shared_ptr<::Pistache::Log::LogHandler>
+#ifndef PISTACHE_STRING_LOGGER_T
+#define PISTACHE_STRING_LOGGER_T \
+  std::shared_ptr<::Pistache::Log::StringLogger>
 #endif
 
-#ifndef PISTACHE_DEFAULT_LOGGER
-#define PISTACHE_DEFAULT_LOGGER \
-  std::make_shared<::Pistache::Log::DefaultLogHandler>(::Pistache::Log::Level::WARN)
+#ifndef PISTACHE_DEFAULT_STRING_LOGGER
+#define PISTACHE_DEFAULT_STRING_LOGGER \
+  std::make_shared<::Pistache::Log::DefaultStringLogger>(::Pistache::Log::Level::WARN)
 #endif
 
-#ifndef PISTACHE_NULL_LOGGER
-#define PISTACHE_NULL_LOGGER \
+#ifndef PISTACHE_NULL_STRING_LOGGER
+#define PISTACHE_NULL_STRING_LOGGER \
   nullptr
 #endif
 

--- a/include/pistache/ssl_wrappers.h
+++ b/include/pistache/ssl_wrappers.h
@@ -26,11 +26,25 @@ struct SSLCtxDeleter {
   }
 };
 
+struct SSLBioDeleter {
+  void operator()(void *ptr) {
+#ifdef PISTACHE_USE_SSL
+    BIO_free(reinterpret_cast<BIO *>(ptr));
+#else
+    (void)ptr;
+#endif
+  }
+};
+
 using SSLCtxPtr = std::unique_ptr<void, SSLCtxDeleter>;
+using SSLBioPtr = std::unique_ptr<void, SSLBioDeleter>;
 
 #ifdef PISTACHE_USE_SSL
 inline SSL_CTX* GetSSLContext(ssl::SSLCtxPtr &ctx) {
     return reinterpret_cast<SSL_CTX *>(ctx.get());
+}
+inline BIO* GetSSLBio(ssl::SSLBioPtr &ctx) {
+    return reinterpret_cast<BIO *>(ctx.get());
 }
 #endif
 

--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -1,0 +1,36 @@
+/* log.cc
+   Michael Ellison, 27 May 2020
+
+   Implementation of the default logger
+*/
+
+#include <iostream>
+
+#include <pistache/log.h>
+
+namespace Pistache {
+namespace Log {
+
+void DefaultLogHandler::log(Level level, const std::string &message) {
+  if (isEnabledFor(level)) {
+    std::cerr << message << std::endl;
+  }
+}
+
+bool DefaultLogHandler::isEnabledFor(Level level) const {
+  return static_cast<int>(level) >= static_cast<int>(level_);
+}
+
+#ifndef PISTACHE_LOG
+#define PISTACHE_LOG(level, logger, message) do {\
+  if (logger->isEnabledFor(level)) { \
+    std::ostringstream oss_; \
+    logger->log(level, oss_.str(oss_ << message)); \
+  } \
+} while (0)
+#endif
+
+} // namespace Log
+} // namespace Pistache
+
+

--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -21,15 +21,6 @@ bool DefaultLogHandler::isEnabledFor(Level level) const {
   return static_cast<int>(level) >= static_cast<int>(level_);
 }
 
-#ifndef PISTACHE_LOG
-#define PISTACHE_LOG(level, logger, message) do {\
-  if (logger->isEnabledFor(level)) { \
-    std::ostringstream oss_; \
-    logger->log(level, oss_.str(oss_ << message)); \
-  } \
-} while (0)
-#endif
-
 } // namespace Log
 } // namespace Pistache
 

--- a/src/common/log.cc
+++ b/src/common/log.cc
@@ -11,13 +11,13 @@
 namespace Pistache {
 namespace Log {
 
-void DefaultLogHandler::log(Level level, const std::string &message) {
+void DefaultStringLogger::log(Level level, const std::string &message) {
   if (isEnabledFor(level)) {
     std::cerr << message << std::endl;
   }
 }
 
-bool DefaultLogHandler::isEnabledFor(Level level) const {
+bool DefaultStringLogger::isEnabledFor(Level level) const {
   return static_cast<int>(level) >= static_cast<int>(level_);
 }
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -15,7 +15,8 @@ namespace Http {
 Endpoint::Options::Options()
     : threads_(1), flags_(), backlog_(Const::MaxBacklog),
       maxRequestSize_(Const::DefaultMaxRequestSize),
-      maxResponseSize_(Const::DefaultMaxResponseSize) {}
+      maxResponseSize_(Const::DefaultMaxResponseSize),
+      logger_(PISTACHE_NULL_LOGGER) {}
 
 Endpoint::Options &Endpoint::Options::threads(int val) {
   threads_ = val;
@@ -51,6 +52,11 @@ Endpoint::Options &Endpoint::Options::maxResponseSize(size_t val) {
   return *this;
 }
 
+Endpoint::Options &Endpoint::Options::logger(PISTACHE_LOGGER_T logger) {
+  logger_ = logger;
+  return *this;
+}
+
 Endpoint::Endpoint() {}
 
 Endpoint::Endpoint(const Address &addr) : listener(addr) {}
@@ -59,6 +65,7 @@ void Endpoint::init(const Endpoint::Options &options) {
   listener.init(options.threads_, options.flags_, options.threadsName_);
   maxRequestSize_ = options.maxRequestSize_;
   maxResponseSize_ = options.maxResponseSize_;
+  logger_ = options.logger_;
 }
 
 void Endpoint::setHandler(const std::shared_ptr<Handler> &handler) {

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -16,7 +16,7 @@ Endpoint::Options::Options()
     : threads_(1), flags_(), backlog_(Const::MaxBacklog),
       maxRequestSize_(Const::DefaultMaxRequestSize),
       maxResponseSize_(Const::DefaultMaxResponseSize),
-      logger_(PISTACHE_NULL_LOGGER) {}
+      logger_(PISTACHE_NULL_STRING_LOGGER) {}
 
 Endpoint::Options &Endpoint::Options::threads(int val) {
   threads_ = val;
@@ -52,7 +52,7 @@ Endpoint::Options &Endpoint::Options::maxResponseSize(size_t val) {
   return *this;
 }
 
-Endpoint::Options &Endpoint::Options::logger(PISTACHE_LOGGER_T logger) {
+Endpoint::Options &Endpoint::Options::logger(PISTACHE_STRING_LOGGER_T logger) {
   logger_ = logger;
   return *this;
 }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -88,7 +88,8 @@ Listener::~Listener() {
 }
 
 void Listener::init(size_t workers, Flags<Options> options,
-                    const std::string &workersName, int backlog) {
+                    const std::string &workersName, int backlog,
+                    PISTACHE_LOGGER_T logger) {
   if (workers > hardware_concurrency()) {
     // Log::warning() << "More workers than available cores"
   }
@@ -98,6 +99,7 @@ void Listener::init(size_t workers, Flags<Options> options,
   useSSL_ = false;
   workers_ = workers;
   workersName_ = workersName;
+  logger_ = logger;
 }
 
 void Listener::setHandler(const std::shared_ptr<Handler> &handler) {
@@ -225,9 +227,9 @@ void Listener::run() {
           try {
             handleNewConnection();
           } catch (SocketError &ex) {
-            std::cerr << "Server: " << ex.what() << std::endl;
+            PISTACHE_LOG_WARN(logger_, "Socket error: " << ex.what());
           } catch (ServerError &ex) {
-            std::cerr << "Server: " << ex.what() << std::endl;
+            PISTACHE_LOG_FATAL(logger_, "Server error: " << ex.what());
             throw;
           }
         }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -172,7 +172,7 @@ Listener::~Listener() {
 
 void Listener::init(size_t workers, Flags<Options> options,
                     const std::string &workersName, int backlog,
-                    PISTACHE_LOGGER_T logger) {
+                    PISTACHE_STRING_LOGGER_T logger) {
   if (workers > hardware_concurrency()) {
     // Log::warning() << "More workers than available cores"
   }
@@ -310,9 +310,9 @@ void Listener::run() {
           try {
             handleNewConnection();
           } catch (SocketError &ex) {
-            PISTACHE_LOG_WARN(logger_, "Socket error: " << ex.what());
+            PISTACHE_LOG_STRING_WARN(logger_, "Socket error: " << ex.what());
           } catch (ServerError &ex) {
-            PISTACHE_LOG_FATAL(logger_, "Server error: " << ex.what());
+            PISTACHE_LOG_STRING_FATAL(logger_, "Server error: " << ex.what());
             throw;
           }
         }
@@ -412,7 +412,7 @@ void Listener::handleNewConnection() {
     if (SSL_accept(ssl_data) <= 0) {
       std::string err = "SSL connection error: "
                         + ssl_print_errors_to_string();
-      PISTACHE_LOG_INFO(logger_, err);
+      PISTACHE_LOG_STRING_INFO(logger_, err);
       SSL_free(ssl_data);
       close(client_fd);
       return;
@@ -464,7 +464,7 @@ void Listener::setupSSLAuth(const std::string &ca_file,
 
   if (ssl_ctx_ == nullptr) {
     std::string err = "SSL Context is not initialized";
-    PISTACHE_LOG_FATAL(logger_, err);
+    PISTACHE_LOG_STRING_FATAL(logger_, err);
     throw std::runtime_error(err);
   }
 
@@ -477,7 +477,7 @@ void Listener::setupSSLAuth(const std::string &ca_file,
                                     __ca_path) <= 0) {
     std::string err = "SSL error - Cannot verify SSL locations: "
                       + ssl_print_errors_to_string();
-    PISTACHE_LOG_FATAL(logger_, err);
+    PISTACHE_LOG_STRING_FATAL(logger_, err);
     throw std::runtime_error(err);
   }
 
@@ -501,7 +501,7 @@ void Listener::setupSSL(const std::string &cert_path,
   try {
     ssl_ctx_ = ssl_create_context(cert_path, key_path, use_compression);
   } catch (std::exception &e) {
-    PISTACHE_LOG_FATAL(logger_, e.what());
+    PISTACHE_LOG_STRING_FATAL(logger_, e.what());
     throw;
   }
   useSSL_ = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ pistache_test(stream_test)
 pistache_test(reactor_test)
 pistache_test(threadname_test)
 pistache_test(optional_test)
+pistache_test(logger_test)
 
 if (PISTACHE_USE_SSL)
 

--- a/tests/logger_test.cc
+++ b/tests/logger_test.cc
@@ -1,0 +1,68 @@
+#include <utility>
+#include <vector>
+
+#include <pistache/log.h>
+
+#include "gtest/gtest.h"
+
+using namespace Pistache;
+
+class TestLogHandler : public Log::LogHandler {
+public:
+  void log(Log::Level level, const std::string &message) {
+    messages_.push_back(message);
+    levels_.push_back(level);
+  }
+
+  bool isEnabledFor(Log::Level level) const override {
+    return static_cast<int>(level) >= static_cast<int>(level_);
+  }
+
+  TestLogHandler(Log::Level level) : level_(level) {}
+
+  Log::Level level_;
+
+  std::vector<std::string> messages_;
+  std::vector<Log::Level>  levels_;
+};
+
+TEST(logger_test, basic_log_handler) {
+  auto logger_subclass = std::make_unique<TestLogHandler>(Log::Level::WARN);
+  auto& actual_messages = logger_subclass->messages_;
+  auto& actual_levels = logger_subclass->levels_;
+
+  DECLARE_PISTACHE_LOGGER(logger) = std::move(logger_subclass);
+
+  PISTACHE_LOG(FATAL, logger, "test_message_1_fatal");
+  PISTACHE_LOG(ERROR, logger, "test_message_2_error");
+  PISTACHE_LOG(WARN,  logger, "test_message_3_warn");
+  PISTACHE_LOG(INFO,  logger, "test_message_4_info");
+  PISTACHE_LOG(DEBUG, logger, "test_message_5_debug");
+  PISTACHE_LOG(TRACE, logger, "test_message_6_trace");
+
+  std::vector<std::string> expected_messages;
+  expected_messages.push_back("test_message_1_fatal");
+  expected_messages.push_back("test_message_2_error");
+  expected_messages.push_back("test_message_3_warn");
+
+  std::vector<Log::Level> expected_levels;
+  expected_levels.push_back(Log::Level::FATAL);
+  expected_levels.push_back(Log::Level::ERROR);
+  expected_levels.push_back(Log::Level::WARN);
+
+  ASSERT_EQ(actual_messages, expected_messages);
+  ASSERT_EQ(actual_levels, expected_levels);
+}
+
+TEST(logger_test, basic_log_handler_uninitialized) {
+  DECLARE_PISTACHE_LOGGER(logger) = nullptr;
+
+  PISTACHE_LOG(FATAL, logger, "test_message_1_fatal");
+  PISTACHE_LOG(ERROR, logger, "test_message_2_error");
+  PISTACHE_LOG(WARN,  logger, "test_message_3_warn");
+  PISTACHE_LOG(INFO,  logger, "test_message_4_info");
+  PISTACHE_LOG(DEBUG, logger, "test_message_5_debug");
+  PISTACHE_LOG(TRACE, logger, "test_message_6_trace");
+
+  // Expect no death from accessing the nullptr.
+}

--- a/tests/logger_test.cc
+++ b/tests/logger_test.cc
@@ -7,7 +7,7 @@
 
 using namespace Pistache;
 
-class TestLogHandler : public Log::LogHandler {
+class TestStringLogger : public Log::StringLogger {
 public:
   void log(Log::Level level, const std::string &message) {
     messages_.push_back(message);
@@ -28,7 +28,7 @@ public:
     }
   }
 
-  TestLogHandler(Log::Level level) : level_(level) {}
+  TestStringLogger(Log::Level level) : level_(level) {}
 
   Log::Level level_;
 
@@ -36,20 +36,20 @@ public:
   std::vector<Log::Level>  levels_;
 };
 
-// Test that isEnabledFor is called when using the PISTACHE_LOG_* macros.
+// Test that isEnabledFor is called when using the PISTACHE_LOG_STRING_* macros.
 TEST(logger_test, macros_guard_by_level) {
-  auto logger_subclass = std::make_shared<TestLogHandler>(Log::Level::WARN);
+  auto logger_subclass = std::make_shared<TestStringLogger>(Log::Level::WARN);
   auto& actual_messages = logger_subclass->messages_;
   auto& actual_levels = logger_subclass->levels_;
 
-  std::shared_ptr<::Pistache::Log::LogHandler> logger = logger_subclass;
+  std::shared_ptr<::Pistache::Log::StringLogger> logger = logger_subclass;
 
-  PISTACHE_LOG_FATAL(logger, "test_message_1_fatal");
-  PISTACHE_LOG_ERROR(logger, "test_message_2_error");
-  PISTACHE_LOG_WARN(logger,  "test_message_3_warn");
-  PISTACHE_LOG_INFO(logger,  "test_message_4_info");
-  PISTACHE_LOG_DEBUG(logger, "test_message_5_debug");
-  PISTACHE_LOG_TRACE(logger, "test_message_6_trace");
+  PISTACHE_LOG_STRING_FATAL(logger, "test_message_1_fatal");
+  PISTACHE_LOG_STRING_ERROR(logger, "test_message_2_error");
+  PISTACHE_LOG_STRING_WARN(logger,  "test_message_3_warn");
+  PISTACHE_LOG_STRING_INFO(logger,  "test_message_4_info");
+  PISTACHE_LOG_STRING_DEBUG(logger, "test_message_5_debug");
+  PISTACHE_LOG_STRING_TRACE(logger, "test_message_6_trace");
 
   std::vector<std::string> expected_messages;
   expected_messages.push_back("test_message_1_fatal");
@@ -65,30 +65,30 @@ TEST(logger_test, macros_guard_by_level) {
   ASSERT_EQ(actual_levels, expected_levels);
 }
 
-// Test that the PISTACHE_LOG_* macros guard against accessing a null logger.
+// Test that the PISTACHE_LOG_STRING_* macros guard against accessing a null logger.
 TEST(logger_test, macros_guard_null_logger) {
-  PISTACHE_LOGGER_T logger = PISTACHE_NULL_LOGGER;
+  PISTACHE_STRING_LOGGER_T logger = PISTACHE_NULL_STRING_LOGGER;
 
-  PISTACHE_LOG_FATAL(logger, "test_message_1_fatal");
-  PISTACHE_LOG_ERROR(logger, "test_message_2_error");
-  PISTACHE_LOG_WARN(logger,  "test_message_3_warn");
-  PISTACHE_LOG_INFO(logger,  "test_message_4_info");
-  PISTACHE_LOG_DEBUG(logger, "test_message_5_debug");
-  PISTACHE_LOG_TRACE(logger, "test_message_6_trace");
+  PISTACHE_LOG_STRING_FATAL(logger, "test_message_1_fatal");
+  PISTACHE_LOG_STRING_ERROR(logger, "test_message_2_error");
+  PISTACHE_LOG_STRING_WARN(logger,  "test_message_3_warn");
+  PISTACHE_LOG_STRING_INFO(logger,  "test_message_4_info");
+  PISTACHE_LOG_STRING_DEBUG(logger, "test_message_5_debug");
+  PISTACHE_LOG_STRING_TRACE(logger, "test_message_6_trace");
 
   // Expect no death from accessing the default logger.
 }
 
-// Test that the PISTACHE_LOG_* macros access a default logger.
+// Test that the PISTACHE_LOG_STRING_* macros access a default logger.
 TEST(logger_test, macros_access_default_logger) {
-  PISTACHE_LOGGER_T logger = PISTACHE_DEFAULT_LOGGER;
+  PISTACHE_STRING_LOGGER_T logger = PISTACHE_DEFAULT_STRING_LOGGER;
 
-  PISTACHE_LOG_FATAL(logger, "test_message_1_fatal");
-  PISTACHE_LOG_ERROR(logger, "test_message_2_error");
-  PISTACHE_LOG_WARN(logger,  "test_message_3_warn");
-  PISTACHE_LOG_INFO(logger,  "test_message_4_info");
-  PISTACHE_LOG_DEBUG(logger, "test_message_5_debug");
-  PISTACHE_LOG_TRACE(logger, "test_message_6_trace");
+  PISTACHE_LOG_STRING_FATAL(logger, "test_message_1_fatal");
+  PISTACHE_LOG_STRING_ERROR(logger, "test_message_2_error");
+  PISTACHE_LOG_STRING_WARN(logger,  "test_message_3_warn");
+  PISTACHE_LOG_STRING_INFO(logger,  "test_message_4_info");
+  PISTACHE_LOG_STRING_DEBUG(logger, "test_message_5_debug");
+  PISTACHE_LOG_STRING_TRACE(logger, "test_message_6_trace");
 
   // Expect no death from using the default handler. The only output of the 
   // default logger is to stdout, so output cannot be confirmed by gtest.


### PR DESCRIPTION
Implement a logging API using a collection of PISTACHE_LOG* macros to be used internally.

Users of pre-compiled Pistache can provide an alternative implementation of a LogHandler to direct log messages as required. Users compiling Pistache can include patches to modify the PISTACHE_LOG* macros to use an alternative logging engine if required.

This PR also includes additions to the ssl wrappers to handle OpenSSL BIO objects and some other SSL helpers.