### PR TITLE
Ensure no epoll events are processed for closed peer files

### DIFF
--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -120,6 +120,8 @@ public:
   void modifyFd(const Key &key, Fd fd, Polling::NotifyOn interest,
                 Polling::Tag tag, Polling::Mode mode = Polling::Mode::Level);
 
+  void removeFd(const Key& key, Fd fd);
+
   void runOnce();
   void run();
 

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -43,6 +43,8 @@ public:
                         Polling::NotifyOn interest, Polling::Tag tag,
                         Polling::Mode mode = Polling::Mode::Level) = 0;
 
+  virtual void removeFd(const Reactor::Key& key, Fd fd) = 0;
+
   virtual void runOnce() = 0;
   virtual void run() = 0;
 
@@ -110,6 +112,10 @@ public:
 
     auto pollTag = encodeTag(key, tag);
     poller.rearmFd(fd, Flags<Polling::NotifyOn>(interest), pollTag, mode);
+  }
+
+  void removeFd(const Reactor::Key& key, Fd fd) override {
+    poller.removeFd(fd);
   }
 
   void runOnce() override {
@@ -375,6 +381,10 @@ public:
     dispatchCall(key, &SyncImpl::modifyFd, fd, interest, tag, mode);
   }
 
+  void removeFd(const Reactor::Key& key, Fd fd) override {
+    dispatchCall(key, &SyncImpl::removeFd, fd);
+  }
+
   void runOnce() override {}
 
   void run() override {
@@ -509,6 +519,10 @@ void Reactor::modifyFd(const Reactor::Key &key, Fd fd,
 void Reactor::modifyFd(const Reactor::Key &key, Fd fd,
                        Polling::NotifyOn interest, Polling::Mode mode) {
   impl()->modifyFd(key, fd, interest, Polling::Tag(fd), mode);
+}
+
+void Reactor::removeFd(const Reactor::Key& key, Fd fd) {
+  impl()->removeFd(key, fd);
 }
 
 void Reactor::run() { impl()->run(); }

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -427,8 +427,9 @@ void Listener::handleNewConnection() {
 
 int Listener::acceptConnection(struct sockaddr_in &peer_addr) const {
   socklen_t peer_addr_len = sizeof(peer_addr);
-  int client_fd =
-      ::accept(listen_fd, (struct sockaddr *)&peer_addr, &peer_addr_len);
+  // Do not share open FD with forked processes
+  int client_fd = ::accept4(
+    listen_fd, (struct sockaddr *)&peer_addr, &peer_addr_len, SOCK_CLOEXEC);
   if (client_fd < 0) {
     if (errno == EBADF || errno == ENOTSOCK)
       throw ServerError(strerror(errno));


### PR DESCRIPTION
An error existed in transport.cc where it incorrectly assumed that
it would not receive epoll events relating to a closed peer
connection. This is not the case because file descriptors can be
shared between processes e.g. on exec. When they are, events could
still be generated. The solution is to explicitly de-register our
interest in the file descriptor before we close it using
epoll_ctl(EPOLL_CTL_DEL). In addition the call to accept in
listener.cc has been updated to set CLOEXEC on the peer file
descriptors as these should not be shared with other processes
anyway.