### PR TITLE
Fix ResponseStream flush

### DIFF
--- a/include/pistache/string_view.h
+++ b/include/pistache/string_view.h
@@ -218,8 +218,10 @@ public:
     switch (len & 3) {
     case 3:
       k1 ^= tail[2] << 16;
+      /* fall through */
     case 2:
       k1 ^= tail[1] << 8;
+      /* fall through */
     case 1:
       k1 ^= tail[0];
       k1 *= c1;

--- a/include/pistache/transport.h
+++ b/include/pistache/transport.h
@@ -69,6 +69,8 @@ public:
 
   std::shared_ptr<Aio::Handler> clone() const override;
 
+  void flush();
+
 private:
   enum WriteStatus { FirstTry, Retry };
 
@@ -195,7 +197,7 @@ private:
 
   void handlePeerDisconnection(const std::shared_ptr<Peer> &peer);
   void handleIncoming(const std::shared_ptr<Peer> &peer);
-  void handleWriteQueue();
+  void handleWriteQueue(bool flush = false);
   void handleTimerQueue();
   void handlePeerQueue();
   void handleNotify();

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -337,7 +337,7 @@ void Transport::handleReadableEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isReadable() && "Entry must be readable");
 
   auto tag = entry.getTag();
-  auto fd = static_cast<const Fd>(tag.value());
+  const auto fd = static_cast<Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto connection = connIt->second.connection.lock();
@@ -364,7 +364,7 @@ void Transport::handleWritableEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isWritable() && "Entry must be writable");
 
   auto tag = entry.getTag();
-  auto fd = static_cast<const Fd>(tag.value());
+  const auto fd = static_cast<Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto &connectionEntry = connIt->second;
@@ -385,7 +385,7 @@ void Transport::handleHangupEntry(const Aio::FdSet::Entry &entry) {
   assert(entry.isHangup() && "Entry must be hangup");
 
   auto tag = entry.getTag();
-  auto fd = static_cast<const Fd>(tag.value());
+  const auto fd = static_cast<Fd>(tag.value());
   auto connIt = connections.find(fd);
   if (connIt != std::end(connections)) {
     auto &connectionEntry = connIt->second;

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -636,6 +636,7 @@ void ResponseStream::flush() {
 
   auto fd = peer()->fd();
   transport_->asyncWrite(fd, buf);
+  transport_->flush();
 
   buf_.clear();
 }


### PR DESCRIPTION
Very wonky attempt at fixing #786.

`transport_->asyncWrite()` seems to put current buffer to write queue instead of dumping it straight into socket. This isn't a good fix, since we won't dump queued items. @dennisjenkins75 I think you may have a better insight, how it should be done, but `Tcp::Transport` is magic to me at the moment.

However it works fine with following example.
```cpp
#include <chrono>
#include <thread>

#include "pistache/endpoint.h"

using namespace Pistache;

class HelloHandler : public Http::Handler {
public:
    HTTP_PROTOTYPE(HelloHandler)

    void onRequest(const Http::Request& request, Http::ResponseWriter response) override
    {
        UNUSED(request);

        auto stream = response.stream(Http::Code::Ok);
        stream << "Hello ";
        stream.flush();

        std::this_thread::sleep_for(std::chrono::seconds(2));

        stream << "world!";
        stream.ends();
    }
};

int main()
{
    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(9080));
    auto opts = Pistache::Http::Endpoint::options().threads(1);

    Http::Endpoint server(addr);
    server.init(opts);
    server.setHandler(Http::make_handler<HelloHandler>());
    server.serve();
}
```

Also I fixed a few warnings which appear when compiling with GCC 10.
```
../src/client/client.cc: In member function ‘void Pistache::Http::Transport::handleReadableEntry(const Pistache::Aio::FdSet::Entry&)’:
../src/client/client.cc:340:13: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  340 |   auto fd = static_cast<const Fd>(tag.value());
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/client/client.cc: In member function ‘void Pistache::Http::Transport::handleWritableEntry(const Pistache::Aio::FdSet::Entry&)’:
../src/client/client.cc:367:13: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  367 |   auto fd = static_cast<const Fd>(tag.value());
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/client/client.cc: In member function ‘void Pistache::Http::Transport::handleHangupEntry(const Pistache::Aio::FdSet::Entry&)’:
../src/client/client.cc:388:13: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
  388 |   auto fd = static_cast<const Fd>(tag.value());


[22/25] Building CXX object src/CMakeFiles/pistache.dir/server/router.cc.o
In file included from ../include/pistache/router.h:20,
                 from ../include/pistache/description.h:20,
                 from ../src/server/router.cc:9:
../include/pistache/string_view.h: In member function ‘std::string_view::size_type std::hash<std::string_view>::operator()(const std::string_view&) const’:
../include/pistache/string_view.h:220:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  220 |       k1 ^= tail[2] << 16;
      |       ~~~^~~~~~~~~~~~~~~~
../include/pistache/string_view.h:221:5: note: here
  221 |     case 2:
      |     ^~~~
../include/pistache/string_view.h:222:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  222 |       k1 ^= tail[1] << 8;
      |       ~~~^~~~~~~~~~~~~~~
../include/pistache/string_view.h:223:5: note: here
  223 |     case 1:
      |     ^~~~

(... some logs for unused parameter which I've lost)
```
