### PR TITLE
Raw buffer refactoring

### DIFF
--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -103,20 +103,25 @@ private:
   size_t maxSize = Const::MaxBuffer;
 };
 
-struct RawBuffer {
-  RawBuffer();
-  RawBuffer(std::string data, size_t length, bool isDetached = false);
-  RawBuffer(const char *data, size_t length, bool isDetached = false);
+struct RawBuffer final {
+  RawBuffer() = default;
+  RawBuffer(std::string data, size_t length);
+  RawBuffer(const char *data, size_t length);
 
-  RawBuffer detach(size_t fromIndex);
+  RawBuffer(const RawBuffer&) = default;
+  RawBuffer& operator=(const RawBuffer&) = default;
+  RawBuffer(RawBuffer&&) = default;
+  RawBuffer& operator=(RawBuffer&&) = default;
+
+  ~RawBuffer() = default;
+
+  RawBuffer copy(size_t fromIndex = 0u) const;
   const std::string &data() const;
   size_t size() const;
-  bool isDetached() const;
 
 private:
   std::string data_;
-  size_t length_;
-  bool isDetached_;
+  size_t length_ = 0;
 };
 
 struct FileBuffer {

--- a/include/pistache/stream.h
+++ b/include/pistache/stream.h
@@ -108,10 +108,10 @@ struct RawBuffer final {
   RawBuffer(std::string data, size_t length);
   RawBuffer(const char *data, size_t length);
 
-  RawBuffer(const RawBuffer&) = default;
-  RawBuffer& operator=(const RawBuffer&) = default;
-  RawBuffer(RawBuffer&&) = default;
-  RawBuffer& operator=(RawBuffer&&) = default;
+  RawBuffer(const RawBuffer &) = default;
+  RawBuffer &operator=(const RawBuffer &) = default;
+  RawBuffer(RawBuffer &&) = default;
+  RawBuffer &operator=(RawBuffer &&) = default;
 
   ~RawBuffer() = default;
 

--- a/include/pistache/transport.h
+++ b/include/pistache/transport.h
@@ -119,8 +119,8 @@ private:
   };
 
   struct WriteEntry {
-    WriteEntry(Async::Deferred<ssize_t> deferred_, BufferHolder buffer_, Fd peerFd_,
-               int flags_ = 0)
+    WriteEntry(Async::Deferred<ssize_t> deferred_, BufferHolder buffer_,
+               Fd peerFd_, int flags_ = 0)
         : deferred(std::move(deferred_)), buffer(std::move(buffer_)),
           flags(flags_), peerFd(peerFd_) {}
 
@@ -189,7 +189,7 @@ private:
 
   // This will attempt to drain the write queue for the fd
   void asyncWriteImpl(Fd fd);
-  ssize_t sendRawBuffer(Fd fd, const char* buffer, size_t len, int flags);
+  ssize_t sendRawBuffer(Fd fd, const char *buffer, size_t len, int flags);
   ssize_t sendFile(Fd fd, Fd file, off_t offset, size_t len);
 
   void handlePeerDisconnection(const std::shared_ptr<Peer> &peer);

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -17,18 +17,16 @@
 
 namespace Pistache {
 
-RawBuffer::RawBuffer() : data_(), length_(0), isDetached_(false) {}
+RawBuffer::RawBuffer(std::string data, size_t length)
+    : data_(std::move(data)), length_(length) {}
 
-RawBuffer::RawBuffer(std::string data, size_t length, bool isDetached)
-    : data_(std::move(data)), length_(length), isDetached_(isDetached) {}
-
-RawBuffer::RawBuffer(const char *data, size_t length, bool isDetached)
-    : data_(), length_(length), isDetached_(isDetached) {
+RawBuffer::RawBuffer(const char *data, size_t length)
+    : data_(), length_(length) {
   // input may come not from a ZTS - copy only length_ characters.
   data_.assign(data, length_);
 }
 
-RawBuffer RawBuffer::detach(size_t fromIndex) {
+RawBuffer RawBuffer::copy(size_t fromIndex) const {
   if (data_.empty())
     return RawBuffer();
 
@@ -39,14 +37,12 @@ RawBuffer RawBuffer::detach(size_t fromIndex) {
   auto newDatalength = length_ - fromIndex;
   std::string newData = data_.substr(fromIndex, newDatalength);
 
-  return RawBuffer(std::move(newData), newDatalength, true);
+  return RawBuffer(std::move(newData), newDatalength);
 }
 
 const std::string &RawBuffer::data() const { return data_; }
 
 size_t RawBuffer::size() const { return length_; }
-
-bool RawBuffer::isDetached() const { return isDetached_; }
 
 FileBuffer::FileBuffer(const std::string &fileName)
     : fileName_(fileName), fd_(-1), size_(0) {

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -214,10 +214,11 @@ bool match_literal(char c, StreamCursor &cursor, CaseSensitivity cs) {
   if (cursor.eof())
     return false;
 
-  char lhs = (cs == CaseSensitivity::Sensitive ? c : static_cast<char>(std::tolower(c)));
-  char rhs =
-      (cs == CaseSensitivity::Sensitive ? cursor.current()
-                                        : static_cast<char>(std::tolower(cursor.current())));
+  char lhs = (cs == CaseSensitivity::Sensitive ? c : static_cast<char>(
+                                                         std::tolower(c)));
+  char rhs = (cs == CaseSensitivity::Sensitive
+                  ? cursor.current()
+                  : static_cast<char>(std::tolower(cursor.current())));
 
   if (lhs == rhs) {
     cursor.advance(1);
@@ -238,8 +239,12 @@ bool match_until(std::initializer_list<char> chars, StreamCursor &cursor,
 
   auto find = [&](char val) {
     for (auto c : chars) {
-      char lhs = cs == CaseSensitivity::Sensitive ? c : static_cast<char>(std::tolower(c));
-      char rhs = cs == CaseSensitivity::Insensitive ? val : static_cast<char>(std::tolower(val));
+      char lhs = cs == CaseSensitivity::Sensitive
+                     ? c
+                     : static_cast<char>(std::tolower(c));
+      char rhs = cs == CaseSensitivity::Insensitive
+                     ? val
+                     : static_cast<char>(std::tolower(val));
 
       if (lhs == rhs)
         return true;

--- a/tests/stream_test.cc
+++ b/tests/stream_test.cc
@@ -15,21 +15,23 @@ using namespace Pistache;
 TEST(stream, test_buffer) {
   const char str[] = "test_string";
   const size_t len = strlen(str);
-  RawBuffer buffer1(str, len, false);
+  RawBuffer buffer1(str, len);
 
-  RawBuffer buffer2 = buffer1.detach(0);
+  ASSERT_THROW(buffer1.copy(2 * len), std::range_error);
+
+  RawBuffer buffer2 = buffer1.copy();
   ASSERT_EQ(buffer2.size(), len);
-  ASSERT_EQ(buffer2.isDetached(), true);
+  ASSERT_EQ(buffer2.data(), "test_string");
 
   RawBuffer buffer3;
   ASSERT_EQ(buffer3.size(), 0u);
-  ASSERT_EQ(buffer3.isDetached(), false);
 
-  RawBuffer buffer4 = buffer3.detach(0);
+  RawBuffer buffer4 = buffer3.copy();
   ASSERT_EQ(buffer4.size(), 0u);
-  ASSERT_EQ(buffer4.isDetached(), false);
 
-  ASSERT_THROW(buffer1.detach(2 * len), std::range_error);
+  RawBuffer buffer5 = buffer1.copy(5u);
+  ASSERT_EQ(buffer5.size(), 6u);
+  ASSERT_EQ(buffer5.data(), "string");
 }
 
 TEST(stream, test_file_buffer) {
@@ -68,7 +70,6 @@ TEST(stream, test_dyn_buffer) {
   auto rawbuf = buf.buffer();
 
   ASSERT_EQ(rawbuf.size(), 128u);
-  ASSERT_EQ(rawbuf.isDetached(), false);
   ASSERT_EQ(rawbuf.data().size(), 128u);
   ASSERT_EQ(strlen(rawbuf.data().c_str()), 128u);
 }


### PR DESCRIPTION
Hello,

In the is Pull request I'm proposing refactoring in `RawBuffer`.

1) I found `isDetached` method as useless and decided to remove it: what's the reason of using it?
2) Removed redundant `BufferHolder` copy in `Async::Promise<ssize_t>`: `buffer` is already a _copy_ bacause captured by value (`[=]`);
3) Renamed `detach` to `copy` - from my point of view `copy` is more intuative;
4) Removed obsolete tests and added new ones.