### PR TITLE
Check pull requests source code formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ _apt_pkgs: &_apt_pkgs
   - 'gdb'
   - 'lcov'
   - 'cppcheck'
+  - 'clang-format-9'
 
 _apt_srcs: &_apt_srcs
   - 'ubuntu-toolchain-r-test'
@@ -146,6 +147,12 @@ jobs:
         packages: 
           - *_apt_pkgs
           - ['g++-8']
+
+before_install:
+  # Check source code formatting
+  - if [ $TRAVIS_PULL_REQUEST != "false" ]; then changed_src=$(git diff --name-only master...HEAD | egrep "\.(h|cc)$" | grep -v "include/pistache/thirdparty" || [ $? == 1 ]); fi
+  - if [ ! -z "$changed_src" ]; then git-clang-format-9 --quiet --binary $(which clang-format-9) --style llvm --diff master HEAD -- $changed_src > ./clang-format-diff; fi
+  - if [ -s ./clang-format-diff ]; then cat ./clang-format-diff && echo "Format source code according to LLVM style, please" && false; fi
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"


### PR DESCRIPTION
LLVM style is set explicitly as I found out that clang-format default style on my Debian is Google style (idk why, can't find any config for this behavior). And LLVM style is used already in Pistache that's why it's set explicitly.

Comparison is performed based on diff, so only modified lines are checked, not the whole file. Once everything is formatted properly, full check is useless, hence next PR should clang-format all the header and source code files.

Check is performed on pull requests only.

Failure example:
![image](https://user-images.githubusercontent.com/8387054/89730199-3f6e1900-da45-11ea-8620-1a36454d1b1f.png)
