### PR TITLE
CMakeLists.txt: add C language to project statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 project (pistache
-    LANGUAGES CXX)
+    LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This will fix the detection of atomic:

```
-- Performing Test HAVE_CXX_ATOMICS64_WITHOUT_LIB
-- Performing Test HAVE_CXX_ATOMICS64_WITHOUT_LIB - Failed
-- Looking for __atomic_load_8 in atomic
-- Looking for __atomic_load_8 in atomic - not found
CMake Error at CMakeModules/CheckAtomic.cmake:76 (message):
  Host compiler appears to require libatomic for 64-bit operations, but
  cannot find it.
Call Stack (most recent call first):
  CMakeLists.txt:19 (include)
```

Indeed if C language is not enabled, the test will be run with the C++ compiler resulting in the following error:

```
Building CXX object CMakeFiles/cmTC_fad22.dir/CheckFunctionExists.cxx.o
/tmp/instance-0/output-1/host/bin/mipsel-linux-g++ --sysroot=/tmp/instance-0/output-1/host/mipsel-buildroot-linux-gnu/sysroot    -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -D_FORTIFY_SOURCE=1 -Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers -DCHECK_FUNCTION_EXISTS=__atomic_load_8  -DNDEBUG   -o CMakeFiles/cmTC_fad22.dir/CheckFunctionExists.cxx.o -c /tmp/instance-0/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/CMakeFiles/CheckLibraryExists/CheckFunctionExists.cxx
<command-line>: error: new declaration 'char __atomic_load_8()' ambiguates built-in declaration 'long long unsigned int __atomic_load_8(const volatile void*, int)' [-fpermissive]
/tmp/instance-0/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/CMakeFiles/CheckLibraryExists/CheckFunctionExists.cxx:7:3: note: in expansion of macro 'CHECK_FUNCTION_EXISTS'
   CHECK_FUNCTION_EXISTS(void);
   ^~~~~~~~~~~~~~~~~~~~~
/tmp/instance-0/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/CMakeFiles/CheckLibraryExists/CheckFunctionExists.cxx: In function 'int main(int, char**)':
/tmp/instance-0/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/CMakeFiles/CheckLibraryExists/CheckFunctionExists.cxx:17:25: error: too few arguments to function 'long long unsigned int __atomic_load_8(const volatile void*, int)'
   CHECK_FUNCTION_EXISTS();
                         ^
```

whereas with a C compiler, we'll get:

```
Building C object CMakeFiles/cmTC_4b0f4.dir/CheckFunctionExists.c.o
/home/fabrice/buildroot/output/host/bin/riscv32-linux-gcc --sysroot=/home/fabrice/buildroot/output/host/riscv32-buildroot-linux-gnu/sysroot   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -DCHECK_FUNCTION_EXISTS=__atomic_load_8  -DNDEBUG   -o CMakeFiles/cmTC_4b0f4.dir/CheckFunctionExists.c.o   -c /usr/share/cmake-3.16/Modules/CheckFunctionExists.c
<command-line>: warning: conflicting types for built-in function ‘__atomic_load_8’ [-Wbuiltin-declaration-mismatch]
/usr/share/cmake-3.16/Modules/CheckFunctionExists.c:7:3: note: in expansion of macro ‘CHECK_FUNCTION_EXISTS’
   CHECK_FUNCTION_EXISTS(void);
   ^~~~~~~~~~~~~~~~~~~~~
Linking C executable cmTC_4b0f4
/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_4b0f4.dir/link.txt --verbose=1
/home/fabrice/buildroot/output/host/bin/riscv32-linux-gcc --sysroot=/home/fabrice/buildroot/output/host/riscv32-buildroot-linux-gnu/sysroot -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -DCHECK_FUNCTION_EXISTS=__atomic_load_8  -DNDEBUG    CMakeFiles/cmTC_4b0f4.dir/CheckFunctionExists.c.o  -o cmTC_4b0f4  -latomic
```

Fixes:
 - http://autobuild.buildroot.org/results/2bf06c6a9e55b449ec5875cf9415a9e55b2065d6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>