### PR TITLE
Revert "Use a std::shared_ptr<std::string> for the body_ member variable in Pistache::Http::Message"

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -71,14 +71,14 @@ public:
   friend class Private::BodyStep;
   friend class ResponseWriter;
 
-  Message();
+  Message() = default;
   explicit Message(Version version);
 
   Message(const Message &other) = default;
   Message &operator=(const Message &other) = default;
 
-  Message(Message &&other);
-  Message &operator=(Message &&other);
+  Message(Message &&other) = default;
+  Message &operator=(Message &&other) = default;
 
   Version version() const;
   Code code() const;
@@ -91,10 +91,10 @@ public:
   Header::Collection &headers();
 
 protected:
-  Version version_;
+  Version version_ = Version::Http11;
   Code code_;
 
-  std::shared_ptr<std::string> body_;
+  std::string body_;
 
   CookieJar cookies_;
   Header::Collection headers_;

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -743,12 +743,12 @@ RequestBuilder &RequestBuilder::cookie(const Cookie &cookie) {
 }
 
 RequestBuilder &RequestBuilder::body(const std::string &val) {
-  *(request_.body_) = val;
+  request_.body_ = val;
   return *this;
 }
 
 RequestBuilder &RequestBuilder::body(std::string &&val) {
-  *(request_.body_) = std::move(val);
+  request_.body_ = std::move(val);
   return *this;
 }
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -360,7 +360,7 @@ State BodyStep::parseContentLength(
     // We have an incomplete body, read what we can
     if (available < size) {
       cursor.advance(available);
-      message->body_->append(token.rawText(), token.size());
+      message->body_.append(token.rawText(), token.size());
 
       bytesRead += available;
 
@@ -368,7 +368,7 @@ State BodyStep::parseContentLength(
     }
 
     cursor.advance(size);
-    message->body_->append(token.rawText(), token.size());
+    message->body_.append(token.rawText(), token.size());
     return true;
   };
 
@@ -381,7 +381,7 @@ State BodyStep::parseContentLength(
   }
   // This is the first time we are reading the payload
   else {
-    message->body_->reserve(contentLength);
+    message->body_.reserve(contentLength);
     if (!readBody(contentLength))
       return State::Again;
   }
@@ -417,21 +417,21 @@ BodyStep::Chunk::Result BodyStep::Chunk::parse(StreamCursor &cursor) {
   if (size == 0)
     return Final;
 
-  message->body_->reserve(size);
+  message->body_.reserve(size);
   StreamCursor::Token chunkData(cursor);
   const ssize_t available = cursor.remaining();
 
-  if (static_cast<ssize_t>(available + message->body_->size()) < size) {
+  if (static_cast<ssize_t>(available + message->body_.size()) < size) {
     cursor.advance(available);
-    message->body_->append(chunkData.rawText(), available);
+    message->body_.append(chunkData.rawText(), available);
     return Incomplete;
   }
-  cursor.advance(size - message->body_->size());
+  cursor.advance(size - message->body_.size());
 
   if (!cursor.advance(2))
     return Incomplete;
 
-  message->body_->append(chunkData.rawText(), size - message->body_->size());
+  message->body_.append(chunkData.rawText(), size - message->body_.size());
 
   return Complete;
 }
@@ -531,35 +531,13 @@ bool Query::has(const std::string &name) const {
 
 } // namespace Uri
 
-Message::Message() : Message(Version::Http11) {}
-
-Message::Message(Version version)
-    : version_(version), body_(std::make_shared<std::string>()) {}
-
-Message::Message(Message &&other)
-    : version_(std::move(other.version_)), code_(std::move(other.code_)),
-      body_(std::move(other.body_)), cookies_(std::move(other.cookies_)),
-      headers_(std::move(other.headers_)) {
-  other.body_ = std::make_shared<std::string>();
-}
-
-Message &Message::operator=(Message &&other) {
-  version_ = std::move(other.version_);
-  code_ = std::move(other.code_);
-  body_ = std::move(other.body_);
-  cookies_ = std::move(other.cookies_);
-  headers_ = std::move(other.headers_);
-
-  other.body_ = std::make_shared<std::string>();
-
-  return *this;
-}
+Message::Message(Version version) : version_(version) {}
 
 Version Message::version() const { return version_; }
 
 Code Message::code() const { return code_; }
 
-std::string Message::body() const { return *body_; }
+std::string Message::body() const { return body_; }
 
 const Header::Collection &Message::headers() const { return headers_; }
 


### PR DESCRIPTION
Reverts oktal/pistache#814

Causes breakage for two users of pistache.