### PR TITLE
CMakeLists.txt: respect BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage -fstack-protector-all --param=ssp-buffer-size=4")
 endif()
 
+option(BUILD_SHARED_LIBS "build shared library" ON)
 option(PISTACHE_BUILD_TESTS "build tests alongside the project" OFF)
 option(PISTACHE_ENABLE_NETWORK_TESTS "if tests are built, run ones needing network access" ON)
 option(PISTACHE_BUILD_EXAMPLES "build examples alongside the project" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,30 +26,35 @@ set(include_install_dir ${CMAKE_INSTALL_INCLUDEDIR})
 set(lib_install_dir ${CMAKE_INSTALL_LIBDIR})
 set(bin_install_dir ${CMAKE_INSTALL_BINDIR})
 
-add_library(pistache_shared SHARED $<TARGET_OBJECTS:pistache>)
+if (BUILD_SHARED_LIBS)
+    add_library(pistache_shared SHARED $<TARGET_OBJECTS:pistache>)
+    target_link_libraries(pistache_shared PRIVATE Threads::Threads ${CMAKE_REQUIRED_LIBRARIES})
+    target_include_directories(pistache_shared INTERFACE ${PISTACHE_INCLUDE})
+endif ()
+
 add_library(pistache_static STATIC $<TARGET_OBJECTS:pistache>)
-
-target_link_libraries(pistache_shared PRIVATE Threads::Threads ${CMAKE_REQUIRED_LIBRARIES})
 target_link_libraries(pistache_static PRIVATE Threads::Threads ${CMAKE_REQUIRED_LIBRARIES})
-
-target_include_directories(pistache_shared INTERFACE ${PISTACHE_INCLUDE})
 target_include_directories(pistache_static INTERFACE ${PISTACHE_INCLUDE})
 
 if (PISTACHE_USE_SSL)
     target_compile_definitions(pistache PUBLIC PISTACHE_USE_SSL)
-    target_compile_definitions(pistache_shared PUBLIC PISTACHE_USE_SSL)
     target_compile_definitions(pistache_static PUBLIC PISTACHE_USE_SSL)
 
     target_include_directories(pistache PRIVATE ${OPENSSL_INCLUDE_DIR})
-    target_link_libraries(pistache_shared PUBLIC OpenSSL::SSL OpenSSL::Crypto)
     target_link_libraries(pistache_static PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+    if (BUILD_SHARED_LIBS)
+        target_compile_definitions(pistache_shared PUBLIC PISTACHE_USE_SSL)
+        target_link_libraries(pistache_shared PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+    endif ()
 endif ()
 
 set(Pistache_OUTPUT_NAME "pistache")
-set_target_properties(pistache_shared PROPERTIES
-    OUTPUT_NAME ${Pistache_OUTPUT_NAME}-${version}
-    SOVERSION ${SONAME_VERSION_MAJOR}.${SONAME_VERSION_MINOR}
-)
+if (BUILD_SHARED_LIBS)
+    set_target_properties(pistache_shared PROPERTIES
+        OUTPUT_NAME ${Pistache_OUTPUT_NAME}-${version}
+        SOVERSION ${SONAME_VERSION_MAJOR}.${SONAME_VERSION_MINOR}
+    )
+endif ()
 
 set_target_properties(pistache_static PROPERTIES 
     OUTPUT_NAME ${Pistache_OUTPUT_NAME}
@@ -60,13 +65,15 @@ if (PISTACHE_INSTALL)
     set(Pistache_CONFIG_FILE "PistacheConfig.cmake")
     set(Pistache_CONFIG_VERSION_FILE "PistacheConfigVersion.cmake")
 
-    install(
-      TARGETS pistache_shared
-      EXPORT PistacheTargets
-      ARCHIVE DESTINATION ${lib_install_dir}
-      LIBRARY DESTINATION ${lib_install_dir}
-      RUNTIME DESTINATION ${bin_install_dir}
-      INCLUDES DESTINATION ${include_install_dir})
+    if (BUILD_SHARED_LIBS)
+        install(
+          TARGETS pistache_shared
+          EXPORT PistacheTargets
+          ARCHIVE DESTINATION ${lib_install_dir}
+          LIBRARY DESTINATION ${lib_install_dir}
+          RUNTIME DESTINATION ${bin_install_dir}
+          INCLUDES DESTINATION ${include_install_dir})
+    endif ()
 
     install(
       DIRECTORY "${PROJECT_SOURCE_DIR}/include/pistache"


### PR DESCRIPTION
Don't build and install pistache_shared if the standard cmake
BUILD_SHARED_LIBS is set to OFF

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>