### PR TITLE
Add OpenBSD and NetBSD GitHub Workflows

### DIFF
--- a/.github/workflows/netbsd.yaml
+++ b/.github/workflows/netbsd.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 Duncan Greatwood
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Uses: https://github.com/marketplace/actions/netbsd-vm
+
+name: netbsd
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+defaults:
+  run:
+    shell: sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+#        osver: [ '10.0' ]
+#        compiler: [ 'gcc' ]
+#        arch: [ 'x86_64' ]
+#        sanitizer: [ 'address', 'none' ]
+#        tls: [ 'true' ]
+#        def_debug: [ 'true' ]
+
+jobs:
+  netbsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        osver: [ '', '9.0' ]
+        compiler: [ 'gcc' ]
+        arch: [ 'x86_64', 'aarch64' ]
+        sanitizer: [ 'address', 'none' ]
+        tls: [ 'true', 'false' ]
+        def_debug: [ 'true', 'false' ]
+        exclude:
+          - arch: 'aarch64'
+            def_debug: 'true'
+          - arch: 'aarch64'
+            sanitizer: 'none'
+          - arch: 'aarch64'
+            tls: 'false'
+          - arch: 'aarch64'
+            osver: '9.0'
+
+    # Note above: As of Apr/2026, aarch64 is run on an emulator,
+    # making it very slow. When debug output is turned on, some tests
+    # will fail just for being too slow, so we exclude the
+    # arch: 'aarch64' + def_debug: 'true' case.
+    # We also exclude some other arch: 'aarch64' cases to reduce the
+    # size of the matrix
+
+    runs-on: ubuntu-latest
+    name: A job to test in NetBSD
+    env:
+        CC: ${{ matrix.compiler }}
+
+    steps:
+    # For FreeBSD, the closest analog to the install list we use in
+    # linux.yaml would be something like:
+    # pkg install -y $compiler git meson pkgconf cmake brotli brotli zstd rapidjson libevent ca_root_nss curl gnupg doxygen googletest openssl
+    # However, if we do that we get weird seg faults and aborts during
+    # testing, probably because we are using multiple incompatible
+    # versions of one or more library (e.g. incompatible versions of
+    # openssl between googletest and libcurl). To avoid those sort of
+    # problems, we install a minimum list of packages as dependencies.
+    #
+    # For OpenBSD, we minimize the package list similarly to FreeBSD
+    - uses: actions/checkout@v6
+    - name: Test NetBSD
+      id: test
+      uses: vmactions/netbsd-vm@v1
+      with:
+        arch: ${{ matrix.arch }}
+        envs: 'CC'
+        usesh: true
+        prepare: |
+
+
+        run: |
+          echo "Install Dependencies"
+          if [ ${{ matrix.compiler }} = gcc ]; then compiler=""; else compiler="clang"; fi
+          {
+            echo "Attempting to use default NetBSD package repository"
+            /usr/sbin/pkg_add -u curl
+          } || {
+            echo "Default repository failed. Will attempt to use alternate:"
+            export PKG_PATH="http://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r)/All/"
+            echo $PKG_PATH
+            /usr/sbin/pkg_add -u curl
+          }
+          /usr/sbin/pkg_add -u $compiler meson brotli pkgconf rapidjson libevent
+          echo "Configure Meson"
+          if [ ${{ matrix.compiler }} = gcc ]; then CXX=g++; else CXX=clang++ CXX_LD=ld; fi
+          export CXX CXX_LD
+          meson setup build \
+          -DPISTACHE_BUILD_TESTS=true -DPISTACHE_DEBUG=${{ matrix.def_debug }} -DPISTACHE_USE_SSL=${{ matrix.tls }} -DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true -DPISTACHE_USE_CONTENT_ENCODING_BROTLI=true -DPISTACHE_USE_CONTENT_ENCODING_ZSTD=true \
+            --buildtype=debug -Db_coverage=true -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false \
+            || (cat build/meson-logs/meson-log.txt ; false)
+           echo "Build"
+           ninja -C build
+           echo "Test"
+           meson test -C build --verbose
+    # Note: The "run" command is what runs inside NetBSD
+    #
+
+# export PKG_PATH="http://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.0/All/"

--- a/.github/workflows/openbsd.yaml
+++ b/.github/workflows/openbsd.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 Duncan Greatwood
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Uses: https://github.com/marketplace/actions/openbsd-vm
+
+name: openbsd
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+defaults:
+  run:
+    shell: sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  openbsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        osver: [ '', '7.3' ]
+        compiler: [ 'clang' ]
+        arch: [ 'x86_64', 'aarch64' ]
+        sanitizer: [ 'none' ]
+        tls: [ 'true', 'false' ]
+        def_debug: [ 'true', 'false' ]
+        exclude:
+          - arch: 'aarch64'
+            def_debug: 'true'
+          - arch: 'aarch64'
+            tls: 'false'
+
+    # Note above: As of Apr/2026, aarch64 is run on an emulator,
+    # making it very slow. When debug output is turned on, some tests
+    # will fail just for being too slow, so we exclude the
+    # arch: 'aarch64' + def_debug: 'true' case.
+    # We also exclude some other arch: 'aarch64' cases to reduce the
+    # size of the matrix
+
+    runs-on: ubuntu-latest
+    name: A job to test in OpenBSD
+    env:
+        CC: ${{ matrix.compiler }}
+
+    steps:
+    # For FreeBSD, the closest analog to the install list we use in
+    # linux.yaml would be something like:
+    # pkg install -y $compiler git meson pkgconf cmake brotli brotli zstd rapidjson libevent ca_root_nss curl gnupg doxygen googletest openssl
+    # However, if we do that we get weird seg faults and aborts during
+    # testing, probably because we are using multiple incompatible
+    # versions of one or more library (e.g. incompatible versions of
+    # openssl between googletest and libcurl). To avoid those sort of
+    # problems, we install a minimum list of packages as dependencies.
+    #
+    # For OpenBSD, we minimize the package list similarly to FreeBSD
+    - uses: actions/checkout@v6
+    - name: Test OpenBSD
+      id: test
+      uses: vmactions/openbsd-vm@v1
+      with:
+        arch: ${{ matrix.arch }}
+        envs: 'CC'
+        usesh: true
+        prepare: |
+
+
+        run: |
+          echo "Install Dependencies"
+          if [ ${{ matrix.compiler }} = gcc ]; then compiler=gcc; else compiler=""; fi
+          pkg_add -I $compiler curl meson brotli rapidjson libevent
+          echo "Configure Meson"
+          if [ ${{ matrix.compiler }} = gcc ]; then CXX=g++; else CXX=clang++ CXX_LD=ld; fi
+          export CXX CXX_LD
+          meson setup build \
+          -DPISTACHE_BUILD_TESTS=true -DPISTACHE_DEBUG=${{ matrix.def_debug }} -DPISTACHE_USE_SSL=${{ matrix.tls }} -DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true -DPISTACHE_USE_CONTENT_ENCODING_BROTLI=true -DPISTACHE_USE_CONTENT_ENCODING_ZSTD=true \
+            --buildtype=debug -Db_coverage=true -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false \
+            || (cat build/meson-logs/meson-log.txt ; false)
+           echo "Build"
+           ninja -C build
+           echo "Test"
+           meson test -C build --verbose
+    # Note: The "run" command is what runs inside OpenBSD

--- a/Building on BSD - FreeBSD, OpenBSD and NetBSD.txt
+++ b/Building on BSD - FreeBSD, OpenBSD and NetBSD.txt
@@ -71,6 +71,8 @@ Typically, required packages are installed using:
 For instance:
   sudo pkg_in install meson
 Do this for each Pistache dependency, excluding howard-hinnant-date.
+Note: You may need to use pkg_add, or /usr/sbin/pkg_add, rather than
+"pkg_in install".
 
 Regarding NetBSD 9.4. NetBSD 9.4 uses gcc 7.5.0, while Pistache's
 build files require C++17 support, and Pistache's code uses

--- a/include/pistache/pist_syslog.h
+++ b/include/pistache/pist_syslog.h
@@ -10,7 +10,7 @@
  * Logging Facilities
  *
  * #include <pistache/pist_syslog.h>
- * 
+ *
  */
 
 
@@ -94,7 +94,7 @@
 // property value other than 0, 1 or 10 is treated like 1. Deleting the
 // property or key is treated like 0. If the property value is changed while
 // pistache.dll is running, the log output behavior will update dynamically.
-// 
+//
 // #define PS_LOG_AND_STDOUT true
 
 #ifndef PS_LOG_AND_STDOUT
@@ -132,6 +132,30 @@
 #define PS_LOG_FNNAME
 #endif
 
+// The "true"s below means send to stdout in addition to log
+#define PS_LOG_AND_SOUT_ALERT_ARGS(__fmt, ...)                          \
+    PSLogFn(LOG_ALERT, true, __FILE__, __LINE__, __FUNCTION__,          \
+            __fmt, __VA_ARGS__)
+
+#define PS_LOG_AND_SOUT_ERR_ARGS(__fmt, ...)                 \
+    PSLogFn(LOG_ERR, true, __FILE__, __LINE__, __FUNCTION__, \
+            __fmt, __VA_ARGS__)
+
+#define PS_LOG_AND_SOUT_WARNING_ARGS(__fmt, ...)                 \
+    PSLogFn(LOG_WARNING, true, __FILE__, __LINE__, __FUNCTION__, \
+            __fmt, __VA_ARGS__)
+
+#define PS_LOG_AND_SOUT_INFO_ARGS(__fmt, ...)                 \
+    PSLogFn(LOG_INFO, true, __FILE__, __LINE__, __FUNCTION__, \
+            __fmt, __VA_ARGS__)
+
+#ifdef DEBUG
+#define PS_LOG_AND_SOUT_DEBUG_ARGS(__fmt, ...)                 \
+    PSLogFn(LOG_DEBUG, true, __FILE__, __LINE__, __FUNCTION__, \
+            __fmt, __VA_ARGS__)
+#else
+#define PS_LOG_AND_SOUT_DEBUG_ARGS(__fmt, ...) { }
+#endif
 
 // ---------------------------------------------------------------------------
 
@@ -150,7 +174,7 @@ extern "C" void PSLogNoLocFn(int _pri, bool _andPrintf,
 // anything then the _category string will be passed to openlog as the "ident"
 // parm upon the first pistachio log; or if setPsLogCategory is not called,
 // then pistachio will assign a 5-letter ident based on the executable name.
-// 
+//
 // Note that if (and this is NOT RECOMMENDED - instead get the app to call
 // openlog itself before anything is logged) setPsLogCategory is called with
 // NULL or empty string, but then pistachio logs something before the
@@ -189,19 +213,18 @@ public:
     std::ostream error;
     std::ostream alert;
 
-    
+
     PSLogOss();
 };
 
 // extern PSLogOss psLogOss;
 
-    
-    
-    
+
+
+
 
 /*****************************************************************************/
 
 #endif // of ifndef INCLUDED_PS_LOG_H
 
 /*****************************************************************************/
-

--- a/include/pistache/ssl_async.h
+++ b/include/pistache/ssl_async.h
@@ -22,6 +22,7 @@
 
 typedef struct ssl_st SSL;
 typedef struct ssl_ctx_st SSL_CTX;
+struct addrinfo;
 
 // ---------------------------------------------------------------------------
 
@@ -81,6 +82,14 @@ public:
     ~SslAsync();
 
     Fd getFd() const { return(mFd); }
+
+private:
+    // tryToConnectSocket is a helper for the constructor SslAsync::SslAsync
+    em_socket_t tryToConnectSocket(const char * _hostName,
+                                   unsigned int _hostPort,
+                                   int _domain, // AF_INET or AF_INET6
+                                   struct addrinfo * & addrinfo_ptr,
+                                   bool _allowAnotherTry);
 };
 typedef std::shared_ptr<SslAsync> SslAsyncSPtr;
 typedef std::shared_ptr<const SslAsync> SslAsyncSPtrC;

--- a/src/client/ssl_async.cc
+++ b/src/client/ssl_async.cc
@@ -74,14 +74,23 @@ namespace Pistache::Http::Experimental {
 
 // ---------------------------------------------------------------------------
 
-#define SSL_LOG_WRN_CLOSE_AND_THROW(__MSG)                \
+#define SSL_CLOSE_FD_AND_FREE_ADDRINFO                    \
     {                                                     \
-        PS_LOG_WARNING(__MSG);                            \
         auto current_fd = mFd;                            \
         mFd = PS_FD_EMPTY;                                \
         if (current_fd != PS_FD_EMPTY)                    \
             CLOSE_FD(current_fd);                         \
-        if (addrinfo_ptr) ::freeaddrinfo(addrinfo_ptr);   \
+        if (addrinfo_ptr)                                 \
+        {                                                 \
+            ::freeaddrinfo(addrinfo_ptr);                 \
+            addrinfo_ptr = 0;                             \
+        }                                                 \
+    }
+
+#define SSL_LOG_WRN_CLOSE_AND_THROW(__MSG)                \
+    {                                                     \
+        PS_LOG_WARNING(__MSG);                            \
+        SSL_CLOSE_FD_AND_FREE_ADDRINFO;                   \
         throw std::runtime_error(__MSG);                  \
     }
 
@@ -707,56 +716,14 @@ static SSL_CTX * makeSslCtx(const char * _hostChainPemFile)
 }
 
 // ---------------------------------------------------------------------------
+// tryToConnectSocket is a helper for the constructor SslAsync::SslAsync
 
-SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
-                   int _domain, // AF_INET or AF_INET6
-                   bool _doVerification,
-                   const char * _hostChainPemFile) :
-    mFd(PS_FD_EMPTY),
-    mWantsTcpRead(1),
-    mWantsTcpWrite(1),
-    mCallSslReadForSslLib(0),
-    mCallSslWriteForSslLib(0),
-    mDoVerification(_doVerification),
-    mSsl(NULL), mCtxt(NULL)
+em_socket_t SslAsync::tryToConnectSocket(const char * _hostName,
+                                         unsigned int _hostPort,
+                                         int _domain, // AF_INET or AF_INET6
+                                         struct addrinfo * & addrinfo_ptr,
+                                         bool _allowAnotherTry)
 {
-    struct addrinfo * addrinfo_ptr = NULL;
-
-    if (!_hostName)
-    {
-        errno = EINVAL;
-        SSL_LOG_WRN_CLOSE_AND_THROW("Null hostName");
-    }
-
-    if (!_hostChainPemFile)
-    {
-        errno = EINVAL;
-        SSL_LOG_WRN_CLOSE_AND_THROW("Null hostChainPemFile");
-    }
-
-    if (!_hostPort)
-        _hostPort = 443;
-
-    struct addrinfo hints = {};
-    hints.ai_family       = _domain;
-    hints.ai_socktype     = SOCK_STREAM;
-    hints.ai_protocol     = IPPROTO_TCP;
-    std::string host_port_as_sstr(std::to_string(_hostPort));
-
-    PS_LOG_DEBUG_ARGS("Doing getaddrinfo. _hostName %s, _hostPort %u",
-                      _hostName, static_cast<unsigned int>(_hostPort));
-    int res = getaddrinfo(_hostName, host_port_as_sstr.c_str(),
-                          &hints, &addrinfo_ptr);
-    PS_LOG_DEBUG_ARGS("getaddrinfo res %d", res);
-    if (res != 0)
-        SSL_LOG_WRN_CLOSE_AND_THROW("Local getaddrinfo failed");
-
-    initOpenSslIfNotAlready();
-
-    mCtxt = makeSslCtx(_hostChainPemFile);
-    if (!mCtxt)
-        SSL_LOG_WRN_CLOSE_AND_THROW("Could not SSL_CTX_new");
-
     em_socket_t sfd = PST_SOCK_SOCKET(_domain, SOCK_STREAM, 0);
     if (sfd < 0)
         SSL_LOG_WRN_CLOSE_AND_THROW("Could not create socket");
@@ -786,9 +753,19 @@ SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
     mFd = sfd;
     #endif
 
-    mSsl = SSL_new(mCtxt);
-    if (!mSsl)
-        SSL_LOG_WRN_CLOSE_AND_THROW("Could not SSL_new");
+    struct addrinfo hints = {};
+    hints.ai_family       = _domain;
+    hints.ai_socktype     = SOCK_STREAM;
+    hints.ai_protocol     = IPPROTO_TCP;
+    std::string host_port_as_sstr(std::to_string(_hostPort));
+
+    PS_LOG_DEBUG_ARGS("Doing getaddrinfo. _hostName %s, _hostPort %u",
+                      _hostName, static_cast<unsigned int>(_hostPort));
+    int res = getaddrinfo(_hostName, host_port_as_sstr.c_str(),
+                          &hints, &addrinfo_ptr);
+    PS_LOG_DEBUG_ARGS("getaddrinfo res %d", res);
+    if (res != 0)
+        SSL_LOG_WRN_CLOSE_AND_THROW("Local getaddrinfo failed");
 
     // Set the socket to be non blocking.
     int flags = PST_FCNTL(sfd, PST_F_GETFL, 0);
@@ -820,6 +797,7 @@ SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
     mConnecting = 0;
     struct addrinfo * this_addrinfo;
     int last_sock_connect_errno = -1;
+    bool any_no_route_to_host = false;
     for(this_addrinfo = addrinfo_ptr; this_addrinfo;
         this_addrinfo = this_addrinfo->ai_next)
     {
@@ -858,6 +836,12 @@ SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
             mConnecting = 1; //true
             break;
         }
+        if (errno == EHOSTUNREACH)
+        {
+            PS_LOG_DEBUG("No route to host");
+            any_no_route_to_host = true;
+        }
+
         last_sock_connect_errno = errno;
         PS_LOG_DEBUG_ARGS("sock connect error, errno %d, "
                           "sfd %d, ai_addrlen %d, ai_addr %p",
@@ -873,8 +857,82 @@ SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
                              last_sock_connect_errno,
                              PST_STRERROR_R_SE_ERR(last_sock_connect_errno));
         }
+
+        if ((_allowAnotherTry) && (any_no_route_to_host))
+        {
+            if (_domain == AF_INET)
+                _domain = AF_INET6;
+            else if (_domain == AF_INET6)
+                _domain = AF_INET;
+            else
+                SSL_LOG_WRN_CLOSE_AND_THROW("Unexpected _domain");
+
+            // Try again with other domain (AF_INET vs AF_INET6)
+            PS_LOG_DEBUG("Try to connect with other domain (IPv4 vs v6)");
+
+            SSL_CLOSE_FD_AND_FREE_ADDRINFO;
+
+            return(tryToConnectSocket(_hostName, _hostPort, _domain,
+                                      addrinfo_ptr, false /*No more tries*/));
+        }
+
         SSL_LOG_WRN_CLOSE_AND_THROW("Failed to start connecting");
     }
+
+    return(sfd);
+}
+
+
+
+// ---------------------------------------------------------------------------
+
+SslAsync::SslAsync(const char * _hostName, unsigned int _hostPort,
+                   int _domain, // AF_INET or AF_INET6
+                   bool _doVerification,
+                   const char * _hostChainPemFile) :
+    mFd(PS_FD_EMPTY),
+    mWantsTcpRead(1),
+    mWantsTcpWrite(1),
+    mCallSslReadForSslLib(0),
+    mCallSslWriteForSslLib(0),
+    mDoVerification(_doVerification),
+    mSsl(NULL), mCtxt(NULL)
+{
+    struct addrinfo * addrinfo_ptr = NULL;
+
+    if (!_hostName)
+    {
+        errno = EINVAL;
+        SSL_LOG_WRN_CLOSE_AND_THROW("Null hostName");
+    }
+
+    if (!_hostChainPemFile)
+    {
+        errno = EINVAL;
+        SSL_LOG_WRN_CLOSE_AND_THROW("Null hostChainPemFile");
+    }
+
+    if (!_hostPort)
+        _hostPort = 443;
+
+    PS_LOG_DEBUG_ARGS("_hostChainPemFile %s, _hostPort %u",
+                      _hostChainPemFile, _hostPort);
+
+    initOpenSslIfNotAlready();
+
+    mCtxt = makeSslCtx(_hostChainPemFile);
+    if (!mCtxt)
+        SSL_LOG_WRN_CLOSE_AND_THROW("Could not SSL_CTX_new");
+
+    em_socket_t sfd = tryToConnectSocket(
+        _hostName, _hostPort, _domain, addrinfo_ptr,
+        true/*try other domain if first fails to find route to host*/);
+    if (sfd < 0)
+        SSL_LOG_WRN_CLOSE_AND_THROW("tryToConnectSocket failed");
+
+    mSsl = SSL_new(mCtxt);
+    if (!mSsl)
+        SSL_LOG_WRN_CLOSE_AND_THROW("Could not SSL_new");
 
     // Save a pointer to mDoVerification for use in verify_callback
     SSL_set_ex_data(mSsl, 0, &mDoVerification); // 0 is "idx" for app data

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -654,58 +654,62 @@ namespace Pistache::Tcp
                                   &tcp_no_push, &len);
 #endif // of if defined(__NetBSD__) || defined(_IS_WINDOWS) ... else
 
-        if (sock_opt_res == 0)
+        if (sock_opt_res != 0)
         {
-            if (((tcp_no_push == 0) && (msg_more_style)) || ((tcp_no_push != 0) && (!msg_more_style)))
-            {
-                PS_LOG_DEBUG_ARGS("Setting MSG_MORE style to %s",
-                                  (msg_more_style) ? "on" : "off");
-
-                PST_SOCK_OPT_VAL_TYPICAL_T optval =
-#ifdef PS_USE_TCP_NODELAY
-                    // In NetBSD case we're getting/setting (or resetting) the
-                    // TCP_NODELAY socket option, which _stops_ data being held
-                    // prior to send, whereas in Linux, macOS, FreeBSD or
-                    // OpenBSD we're using TCP_CORK/TCP_NOPUSH which may
-                    // _cause_ data to be held prior to send. I.e. they're
-                    // opposites.
-                    msg_more_style ? 0 : 1;
-#else
-                    msg_more_style ? 1 : 0;
-#endif
-
-                sock_opt_res = setsockopt(
-                    GET_ACTUAL_FD(fd), tcp_prot_num_,
-#ifdef PS_USE_TCP_NODELAY
-                    TCP_NODELAY,
-#elif defined __APPLE__ || defined _IS_BSD
-                    TCP_NOPUSH,
-#else
-                        TCP_CORK,
-#endif
-                    reinterpret_cast<PST_SOCK_OPT_VAL_PTR_T>(&optval),
-                    len);
-                if (sock_opt_res < 0)
-                    throw std::runtime_error("setsockopt failed");
-            }
-#ifdef DEBUG
-            else
-            {
-                PS_LOG_DEBUG_ARGS("MSG_MORE style is already %s",
-                                  (msg_more_style ? 1 : 0) ? "on" : "off");
-            }
-#endif
+            PST_DECL_SE_ERR_P_EXTRA;
+            PS_LOG_INFO_ARGS("getsockopt failed for fd %p, actual fd %d, "
+                             "errno %d, err %s",
+                             fd, GET_ACTUAL_FD(fd), errno,
+                             PST_STRERROR_R_ERRNO);
         }
+
+        if ((sock_opt_res != 0) || (((tcp_no_push == 0) && (msg_more_style)) ||
+                                    ((tcp_no_push != 0) && (!msg_more_style))))
+        {
+            PS_LOG_DEBUG_ARGS("Setting MSG_MORE style to %s",
+                              (msg_more_style) ? "on" : "off");
+
+            PST_SOCK_OPT_VAL_TYPICAL_T optval =
+#ifdef PS_USE_TCP_NODELAY
+                // In NetBSD case we're getting/setting (or resetting) the
+                // TCP_NODELAY socket option, which _stops_ data being held
+                // prior to send, whereas in Linux, macOS, FreeBSD or
+                // OpenBSD we're using TCP_CORK/TCP_NOPUSH which may
+                // _cause_ data to be held prior to send. I.e. they're
+                // opposites.
+                msg_more_style ? 0 : 1;
+#else
+            msg_more_style ? 1 : 0;
+#endif
+
+            sock_opt_res = setsockopt(
+                GET_ACTUAL_FD(fd), tcp_prot_num_,
+#ifdef PS_USE_TCP_NODELAY
+                TCP_NODELAY,
+#elif defined __APPLE__ || defined _IS_BSD
+                TCP_NOPUSH,
+#else
+                TCP_CORK,
+#endif
+                reinterpret_cast<PST_SOCK_OPT_VAL_PTR_T>(&optval), len);
+
+            if (sock_opt_res < 0)
+            {
+                PST_DECL_SE_ERR_P_EXTRA;
+                PS_LOG_ERR_ARGS("setsockopt failed for fd %p, actual fd %d, "
+                                "errno %d, err %s",
+                                fd, GET_ACTUAL_FD(fd), errno,
+                                PST_STRERROR_R_ERRNO);
+                // throw std::runtime_error("setsockopt failed");
+            }
+        }
+#ifdef DEBUG
         else
         {
-            PST_DBG_DECL_SE_ERR_P_EXTRA;
-            PS_LOG_DEBUG_ARGS("getsockopt failed for fd %p, actual fd %d, "
-                              "errno %d, err %s",
-                              fd, GET_ACTUAL_FD(fd), errno,
-                              PST_STRERROR_R_ERRNO);
-
-            throw std::runtime_error("getsockopt failed");
+            PS_LOG_DEBUG_ARGS("MSG_MORE style is already %s",
+                              (msg_more_style ? 1 : 0) ? "on" : "off");
         }
+#endif
     }
 #endif // of ifdef _USE_LIBEVENT_LIKE_APPLE
 

--- a/tests/https_client_test_net.cc
+++ b/tests/https_client_test_net.cc
@@ -203,14 +203,17 @@ TEST(https_client_test, one_client_with_nonexisitent_url_request)
 
     bool done  = false;
     bool excep = false;
+    int resp_code = -1;
+
     auto rb       = client.get(server_address);
     try {
         auto response = rb.header<Http::Header::Connection>(
             Http::ConnectionControl::KeepAlive).send();
 
         response.then(
-            [&done](Http::Response rsp) {
-                PS_LOG_DEBUG_ARGS("http rsp code: %d", rsp.code());
+            [&done, &resp_code](Http::Response rsp) {
+                resp_code = static_cast<int>(rsp.code());
+
                 if (rsp.code() == Http::Code::Ok)
                 {
                     done = true;
@@ -242,8 +245,22 @@ TEST(https_client_test, one_client_with_nonexisitent_url_request)
 
     client.shutdown();
 
-    ASSERT_TRUE(excep);
     ASSERT_FALSE(done);
+#ifdef __NetBSD__
+    ASSERT_TRUE((resp_code == -1) || (excep));
+    // Note (April/2026): In NetBSD with some (but not all) networking
+    // libraries / OS configurations, the attempt to reach a non-existent URL
+    // times-out rather than throws an exception.
+    //
+    // For instance, on NetBSD 10.0, we see a timeout in the normal
+    // configuration for GitHub workflow, but an exception if we turn on the
+    // "address" sanitizer.
+    //
+    // In all other OS configurations (Linux, macOS, Windows, FreeBSD, OpenBSD)
+    // we see an exception, not a time-out.
+#else
+    ASSERT_TRUE((resp_code == -1) && (excep));
+#endif
 }
 
 TEST(https_client_test, one_client_with_bad_google_request)

--- a/tests/https_server_test.cc
+++ b/tests/https_server_test.cc
@@ -85,9 +85,10 @@ static void assertCurlVersionInfo(void)
     toLower(sslVersion);
 
     // Perform checks on SSL version.
-    if (sslVersion.find("openssl") == std::string::npos)
+    if ((sslVersion.find("openssl") == std::string::npos) &&
+        (sslVersion.find("libressl") == std::string::npos))
     {
-        FAIL() << "Found cURL '" << curlVersion << "' with SSL Version: '" << sslVersion << "', OpenSSL is required.";
+        FAIL() << "Found cURL '" << curlVersion << "' with SSL Version: '" << sslVersion << "', OpenSSL or LibreSSL are required.";
     }
 }
 


### PR DESCRIPTION
Add OpenBSD and NetBSD GitHub Workflows

Also
  - In testing, allow curl with LibreSSL as OpenSLL alternative
  - Add a note to potentially use pkg_add for NetBSD prerequisites
  - Added PS_LOG_AND_SOUT_xxx macros for use when debugging
  - Allow retry with opposite IPv4 vs v6 case for SSL socket connect
  - In transport.cc, cope if getsockopt fails (still set sock options)
  - In HTTPS test, cope if bad URL results in timeout, not exception